### PR TITLE
Fix/correct simulate for multi qubit gates

### DIFF
--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -100,9 +100,10 @@ A structure representing a quantum multi-body system.
 - `hilbert_space_structure` -- a vector of integers specifying the local hilbert space size for each "body" within the multi-body system. 
 """
 struct MultiBodySystem
+    n_body
     hilbert_space_structure::Vector{Int}
     MultiBodySystem(n_body, hilbert_size_per_body) =
-        new(fill(hilbert_size_per_body, n_body))
+        new(n_body, fill(hilbert_size_per_body, n_body))
 end
 
 function Base.show(io::IO, system::MultiBodySystem)

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -239,7 +239,8 @@ function get_embed_operator(gate::Gate, system::MultiBodySystem)
     else
         gate_to_operator =
             Dict("cz"=>get_embed_controlled_gate_operator(sigma_z(), gate, system),
-            "cx"=>get_embed_controlled_gate_operator(sigma_x(), gate, system))
+            "cx"=>get_embed_controlled_gate_operator(sigma_x(), gate, system),
+            "iswap"=>get_swap(gate, system))
         return gate_to_operator[gate.instruction_symbol]
     end
 end
@@ -275,6 +276,44 @@ function get_controlled_gate_operations_at_qubit(controlled_operator, control, t
         operation_1 = eye()
     end
     return operation_0, operation_1
+end
+
+function get_swap(gate::Gate, system::MultiBodySystem)
+    target_1 = gate.target[1]
+    target_2 = gate.target[2]
+    lower_operators =
+        get_swap_at_qubit(target_1, target_2, 1)
+    for i_qubit = 2:system.n_body
+        upper_operators =
+            get_swap_at_qubit(target_1, target_2, i_qubit)
+        for i_operator in 1:length(lower_operators)
+                lower_operators[i_operator] =
+                    kron(lower_operators[i_operator], upper_operators[i_operator])
+        end
+    end
+    embed_operator = sum(lower_operators)
+    return embed_operator
+end
+    
+function get_swap_at_qubit(target_1, target_2, qubit_index)
+
+    if target_1 == qubit_index
+        operation_1 = projector_0()
+        operation_2 = im*sigma_p()
+        operation_3 = im*sigma_m()
+        operation_4 = projector_1()
+    elseif target_2 == qubit_index
+        operation_1 = projector_0()
+        operation_2 = sigma_m()
+        operation_3 = sigma_p()
+        operation_4 = projector_1()
+    else
+        operation_1 = eye()
+        operation_2 = eye()
+        operation_3 = eye()
+        operation_4 = eye()
+    end
+    return [operation_1, operation_2, operation_3, operation_4]
 end
 
 """

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -249,16 +249,16 @@ function get_embed_controlled_gate_operator(controlled_operator::Operator, gate:
     system::MultiBodySystem)
     control = gate.target[1]
     target = gate.target[2]
-    lower_op_0, lower_op_1 = get_controlled_gate_operations_at_qubit(controlled_operator,
+    lower_op_1, lower_op_2 = get_controlled_gate_operations_at_qubit(controlled_operator,
         control, target, 1)
     for i_qubit = 2:system.n_body
-        upper_op_0, upper_op_1 =
+        upper_op_1, upper_op_2 =
             get_controlled_gate_operations_at_qubit(controlled_operator,
             control, target, i_qubit)
-        lower_op_0 = kron(lower_op_0, upper_op_0)
         lower_op_1 = kron(lower_op_1, upper_op_1)
+        lower_op_2 = kron(lower_op_2, upper_op_2)
     end
-    embed_operator = lower_op_0+lower_op_1
+    embed_operator = lower_op_1+lower_op_2
     return embed_operator
 end
 
@@ -266,16 +266,16 @@ function get_controlled_gate_operations_at_qubit(controlled_operator, control, t
     qubit_index)
 
     if control == qubit_index
-        operation_0 = projector_0()
-        operation_1 = projector_1()
+        operation_1 = projector_0()
+        operation_2 = projector_1()
     elseif target == qubit_index
-        operation_0 = eye()
-        operation_1 = controlled_operator
-    else
-        operation_0 = eye()
         operation_1 = eye()
+        operation_2 = controlled_operator
+    else
+        operation_1 = eye()
+        operation_2 = eye()
     end
-    return operation_0, operation_1
+    return operation_1, operation_2
 end
 
 function get_swap(gate::Gate, system::MultiBodySystem)

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -60,13 +60,24 @@ q[2]:--X----X--
 ```
 """
 function push_gate!(circuit::QuantumCircuit, gate::Gate)
-    push!(circuit.pipeline, [gate])
+    push_gate!(circuit, [gate])
     return circuit
 end
 
 function push_gate!(circuit::QuantumCircuit, gates::Array{Gate})
+    ensure_gates_are_in_circuit(circuit, gates)
     push!(circuit.pipeline, gates)
     return circuit
+end
+
+function ensure_gates_are_in_circuit(circuit::QuantumCircuit, gates::Array{Gate})
+    for gate in gates
+        for target in gate.target
+            if target > circuit.qubit_count
+                throw(DomainError(target, "the gate does no fit in the circuit"))
+            end
+        end
+    end
 end
 
 """

--- a/src/core/quantum_gate.jl
+++ b/src/core/quantum_gate.jl
@@ -46,6 +46,8 @@ sigma_y() = Operator(reshape(Complex.([0.0, im, -im, 0.0]), 2, 2))
 sigma_z() = Operator(reshape(Complex.([1.0, 0.0, 0.0, -1.0]), 2, 2))
 sigma_p() = 0.5*(sigma_x()+im*sigma_y())
 sigma_m() = 0.5*(sigma_x()-im*sigma_y())
+projector_0() = Operator([1 0; 0 0])
+projector_1() = Operator([0 0; 0 1])
 
 hadamard() = Operator(1.0 / sqrt(2.0) * reshape(Complex.([1.0, 1.0, 1.0, -1.0]), 2, 2))
 phase() = Operator(reshape(Complex.([1.0, 0.0, 0.0, im]), 2, 2))

--- a/src/core/quantum_gate.jl
+++ b/src/core/quantum_gate.jl
@@ -4,11 +4,27 @@ struct Gate
     operator::Operator
     target::Array
 
-    Gate(display_symbol, instruction_symbol, operator, target::Array) =
+    function Gate(display_symbol, instruction_symbol, operator, target::Array)
+        ensure_target_qubits_are_different(target)
         new(display_symbol, instruction_symbol, operator, target)
+    end
     Gate(display_symbol, instruction_symbol, operator, target::Int) =
         new(display_symbol, instruction_symbol, operator, [target])
 
+end
+
+function ensure_target_qubits_are_different(target::Array)
+    num_targets = length(target)
+    if num_targets > 1
+        previous_target = target[1]
+        for i = 2:num_targets
+            current_target = target[i]
+            if previous_target == current_target
+                throw(DomainError(current_target,
+                    "The gate uses qubit $current_target more than once!"))
+            end
+        end
+    end
 end
 
 function Base.show(io::IO, gate::Gate)

--- a/test/circuit.jl
+++ b/test/circuit.jl
@@ -86,6 +86,16 @@ end
     @test returned_state ≈ expected_state
 end
 
+@testset "simulate_iswap_gate" begin
+    c = QuantumCircuit(qubit_count = 3, bit_count = 0)
+
+    push_gate!(c, sigma_x(3))
+    push_gate!(c, [iswap(1, 3)])
+    returned_state = simulate(c)
+    expected_state = im*fock(4, 8)
+    @test returned_state ≈ expected_state
+end
+
 @testset "throw_if_gate_outside_circuit" begin
     c = QuantumCircuit(qubit_count = 2, bit_count = 0)
     @test_throws DomainError push_gate!(c, control_x(1, 3))

--- a/test/circuit.jl
+++ b/test/circuit.jl
@@ -85,3 +85,8 @@ end
     expected_state = simulate(c)
     @test returned_state ≈ expected_state
 end
+
+@testset "throw_if_gate_outside_circuit" begin
+    c = QuantumCircuit(qubit_count = 2, bit_count = 0)
+    @test_throws DomainError push_gate!(c, control_x(1, 3))
+end

--- a/test/circuit.jl
+++ b/test/circuit.jl
@@ -59,3 +59,29 @@ end
 
     @test ψ ≈ kron(Ψ_m, Ψ_m)
 end
+
+@testset "simulate_cz_gate" begin
+    c = QuantumCircuit(qubit_count = 3, bit_count = 0)
+
+    push_gate!(c, [sigma_x(1), sigma_x(3)])
+    push_gate!(c, [control_z(3, 1)])
+    returned_state = simulate(c)
+    
+    pop_gate!(c)
+    push_gate!(c, sigma_z(1))
+    expected_state = simulate(c)
+    @test returned_state ≈ expected_state
+end
+
+@testset "simulate_cx_gate" begin
+    c = QuantumCircuit(qubit_count = 3, bit_count = 0)
+
+    push_gate!(c, sigma_x(3))
+    push_gate!(c, [control_x(3, 1)])
+    returned_state = simulate(c)
+    
+    pop_gate!(c)
+    push_gate!(c, sigma_x(1))
+    expected_state = simulate(c)
+    @test returned_state ≈ expected_state
+end

--- a/test/gate.jl
+++ b/test/gate.jl
@@ -48,6 +48,10 @@ using Test
 
 end
 
+@testset "gate_set_exceptions" begin
+    @test_throws DomainError control_x(1, 1)
+end
+
 @testset "tensor_product_single_qubit_gate" begin
 
 


### PR DESCRIPTION
Previously, simulating multi-qubit gates only worked if the control qubit was qubit 1 and if the target qubit was qubit 2. This pull request fixes this problem.