### PR TITLE
Fix/correct multi gate drawing

### DIFF
--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -131,13 +131,7 @@ function Base.show(io::IO, circuit::QuantumCircuit)
     i_step = 1
     for step in circuit.pipeline
         i_step += 1 # the first element of the layout is the qubit tag
-        for i_qubit in range(1, length = circuit.qubit_count)
-            id_wire = 2 * (i_qubit - 1) + 1
-            # qubit wire
-            circuit_layout[id_wire, i_step] = "-----"
-            # spacer line
-            circuit_layout[id_wire+1, i_step] = "     "
-        end
+        add_wires_to_circuit_layout!(circuit_layout, i_step, circuit.qubit_count)
 
         for gate in step
             add_coupling_lines_to_circuit_layout!(circuit_layout, gate, i_step)
@@ -146,6 +140,16 @@ function Base.show(io::IO, circuit::QuantumCircuit)
     end
 
     print_circuit_layout(io, circuit_layout)
+end
+
+function add_wires_to_circuit_layout!(circuit_layout, i_step, num_qubits)
+    for i_qubit in range(1, length = num_qubits)
+        id_wire = 2 * (i_qubit - 1) + 1
+        # qubit wire
+        circuit_layout[id_wire, i_step] = "-----"
+        # spacer line
+        circuit_layout[id_wire+1, i_step] = "     "
+    end
 end
 
 function add_coupling_lines_to_circuit_layout!(circuit_layout, gate, i_step)

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -118,7 +118,22 @@ function Base.show(io::IO, circuit::QuantumCircuit)
     println(io, "   id: $(circuit.id) ")
     println(io, "   qubit_count: $(circuit.qubit_count) ")
     println(io, "   bit_count: $(circuit.bit_count) ")
+    print_circuit_diagram(io, circuit)
+end
 
+function print_circuit_diagram(io, circuit)
+    circuit_layout = get_circuit_layout(circuit)
+    num_wires = size(circuit_layout, 1)
+    pipeline_length = size(circuit_layout, 2)
+    for i_wire in range(1, length = num_wires-1)
+        for i_step in range(1, length = pipeline_length)
+            print(io, circuit_layout[i_wire, i_step])
+        end
+        println(io, "")
+    end
+end
+
+function get_circuit_layout(circuit)
     wire_count = 2 * circuit.qubit_count
     circuit_layout = fill("", (wire_count, length(circuit.pipeline) + 1))
     add_qubit_labels_to_circuit_layout!(circuit_layout, circuit.qubit_count)
@@ -132,8 +147,7 @@ function Base.show(io::IO, circuit::QuantumCircuit)
             add_target_to_circuit_layout!(circuit_layout, gate, i_step)
         end
     end
-
-    print_circuit_layout(io, circuit_layout)
+    return circuit_layout
 end
 
 function add_qubit_labels_to_circuit_layout!(circuit_layout, num_qubits)
@@ -142,14 +156,15 @@ function add_qubit_labels_to_circuit_layout!(circuit_layout, num_qubits)
         circuit_layout[id_wire, 1] = "q[$i_qubit]:"
         circuit_layout[id_wire+1, 1] = String(fill(' ', length(circuit_layout[id_wire, 1])))
     end
+end
 
 function add_wires_to_circuit_layout!(circuit_layout, i_step, num_qubits)
     for i_qubit in range(1, length = num_qubits)
         id_wire = 2 * (i_qubit - 1) + 1
         # qubit wire
-        circuit_layout[id_wire, i_step] = "-----"
+        circuit_layout[id_wire, i_step+1] = "-----"
         # spacer line
-        circuit_layout[id_wire+1, i_step] = "     "
+        circuit_layout[id_wire+1, i_step+1] = "     "
     end
 end
 
@@ -158,9 +173,9 @@ function add_coupling_lines_to_circuit_layout!(circuit_layout, gate, i_step)
     max_wire = 2*(maximum(gate.target)-1)+1
     for i_wire in min_wire+1:max_wire-1
         if iseven(i_wire)
-            circuit_layout[i_wire, i_step] = "  |  "
+            circuit_layout[i_wire, i_step+1] = "  |  "
         else
-            circuit_layout[i_wire, i_step] = "--|--"
+            circuit_layout[i_wire, i_step+1] = "--|--"
         end
     end
 end
@@ -169,18 +184,7 @@ function add_target_to_circuit_layout!(circuit_layout, gate, i_step)
     for i_target in 1:length(gate.target)
         single_target = gate.target[i_target]
         id_wire = 2*(single_target-1)+1
-        circuit_layout[id_wire, i_step] = "--$(gate.display_symbol[i_target])--"
-    end
-end
-
-function print_circuit_layout(io, circuit_layout)
-    num_wires = size(circuit_layout, 1)
-    pipeline_length = size(circuit_layout, 2)
-    for i_wire in range(1, length = num_wires-1)
-        for i_step in range(1, length = pipeline_length)
-            print(io, circuit_layout[i_wire, i_step])
-        end
-        println(io, "")
+        circuit_layout[id_wire, i_step+1] = "--$(gate.display_symbol[i_target])--"
     end
 end
 

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -158,8 +158,14 @@ function Base.show(io::IO, circuit::QuantumCircuit)
         end
     end
 
-    for i_wire in range(1, length = wire_count-1)
-        for i_step in range(1, length = length(circuit.pipeline) + 1)
+    print_circuit_layout(io, circuit_layout)
+end
+
+function print_circuit_layout(io, circuit_layout)
+    num_wires = size(circuit_layout, 1)
+    pipeline_length = size(circuit_layout, 2)
+    for i_wire in range(1, length = num_wires-1)
+        for i_step in range(1, length = pipeline_length)
             print(io, circuit_layout[i_wire, i_step])
         end
         println(io, "")

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -140,21 +140,24 @@ function Base.show(io::IO, circuit::QuantumCircuit)
         end
 
         for gate in step
-            min_wire = 2*(minimum(gate.target)-1)+1
-            max_wire = 2*(maximum(gate.target)-1)+1
-            for i_wire in min_wire+1:max_wire-1
-                if iseven(i_wire)
-                    circuit_layout[i_wire, i_step] = "  |  "
-                else
-                    circuit_layout[i_wire, i_step] = "--|--"
-                end
-            end
-            
+            add_coupling_lines_to_circuit_layout!(circuit_layout, gate, i_step)
             add_target_to_circuit_layout!(circuit_layout, gate, i_step)
         end
     end
 
     print_circuit_layout(io, circuit_layout)
+end
+
+function add_coupling_lines_to_circuit_layout!(circuit_layout, gate, i_step)
+    min_wire = 2*(minimum(gate.target)-1)+1
+    max_wire = 2*(maximum(gate.target)-1)+1
+    for i_wire in min_wire+1:max_wire-1
+        if iseven(i_wire)
+            circuit_layout[i_wire, i_step] = "  |  "
+        else
+            circuit_layout[i_wire, i_step] = "--|--"
+        end
+    end
 end
 
 function add_target_to_circuit_layout!(circuit_layout, gate, i_step)

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -130,7 +130,7 @@ function Base.show(io::IO, circuit::QuantumCircuit)
 
     i_step = 1
     for step in circuit.pipeline
-        i_step += 1 # the first elemet of the layout is the qubit tag
+        i_step += 1 # the first element of the layout is the qubit tag
         for i_qubit in range(1, length = circuit.qubit_count)
             id_wire = 2 * (i_qubit - 1) + 1
             # qubit wire
@@ -140,29 +140,27 @@ function Base.show(io::IO, circuit::QuantumCircuit)
         end
 
         for gate in step
-            for i_qubit in range(1, length = circuit.qubit_count)
-                if (i_qubit in gate.target)
-                    id_wire = 2 * (i_qubit - 1) + 1
-                    id = findfirst(isequal(i_qubit), gate.target)
-                    circuit_layout[id_wire, i_step] = "--$(gate.display_symbol[id])--"
-                    if length(gate.target) > 1 && gate.target[1] == i_qubit
-                        circuit_layout[id_wire+1, i_step] = "  |  "
-                    end
+            min_wire = 2*(minimum(gate.target)-1)+1
+            max_wire = 2*(maximum(gate.target)-1)+1
+            for i_wire in min_wire+1:max_wire-1
+                if iseven(i_wire)
+                    circuit_layout[i_wire, i_step] = "  |  "
+                else
+                    circuit_layout[i_wire, i_step] = "--|--"
                 end
+            end
+            
+            for i_target in 1:length(gate.target)
+                single_target = gate.target[i_target]
+                id_wire = 2*(single_target-1)+1
+                circuit_layout[id_wire, i_step] = "--$(gate.display_symbol[i_target])--"
             end
         end
     end
 
-
-    # circuit_layout[id_wire] = circuit_layout[id_wire] * ".\n"
-    # circuit_layout[id_wire + 1] = circuit_layout[id_wire + 1] * ".\n"
-
-    for i_wire in range(1, length = wire_count)
+    for i_wire in range(1, length = wire_count-1)
         for i_step in range(1, length = length(circuit.pipeline) + 1)
-            # print(io, circuit_layout[i_wire, i_step])
-            # println(io, "  i_wire=", i_wire, " i_step=", i_step)
             print(io, circuit_layout[i_wire, i_step])
-
         end
         println(io, "")
     end

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -121,16 +121,10 @@ function Base.show(io::IO, circuit::QuantumCircuit)
 
     wire_count = 2 * circuit.qubit_count
     circuit_layout = fill("", (wire_count, length(circuit.pipeline) + 1))
-
-    for i_qubit in range(1, length = circuit.qubit_count)
-        id_wire = 2 * (i_qubit - 1) + 1
-        circuit_layout[id_wire, 1] = "q[$i_qubit]:"
-        circuit_layout[id_wire+1, 1] = String(fill(' ', length(circuit_layout[id_wire, 1])))
-    end
-
-    i_step = 1
-    for step in circuit.pipeline
-        i_step += 1 # the first element of the layout is the qubit tag
+    add_qubit_labels_to_circuit_layout!(circuit_layout, circuit.qubit_count)
+    
+    for i_step in 1:length(circuit.pipeline)
+        step = circuit.pipeline[i_step]
         add_wires_to_circuit_layout!(circuit_layout, i_step, circuit.qubit_count)
 
         for gate in step
@@ -141,6 +135,13 @@ function Base.show(io::IO, circuit::QuantumCircuit)
 
     print_circuit_layout(io, circuit_layout)
 end
+
+function add_qubit_labels_to_circuit_layout!(circuit_layout, num_qubits)
+    for i_qubit in range(1, length = num_qubits)
+        id_wire = 2 * (i_qubit - 1) + 1
+        circuit_layout[id_wire, 1] = "q[$i_qubit]:"
+        circuit_layout[id_wire+1, 1] = String(fill(' ', length(circuit_layout[id_wire, 1])))
+    end
 
 function add_wires_to_circuit_layout!(circuit_layout, i_step, num_qubits)
     for i_qubit in range(1, length = num_qubits)

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -150,15 +150,19 @@ function Base.show(io::IO, circuit::QuantumCircuit)
                 end
             end
             
-            for i_target in 1:length(gate.target)
-                single_target = gate.target[i_target]
-                id_wire = 2*(single_target-1)+1
-                circuit_layout[id_wire, i_step] = "--$(gate.display_symbol[i_target])--"
-            end
+            add_target_to_circuit_layout!(circuit_layout, gate, i_step)
         end
     end
 
     print_circuit_layout(io, circuit_layout)
+end
+
+function add_target_to_circuit_layout!(circuit_layout, gate, i_step)
+    for i_target in 1:length(gate.target)
+        single_target = gate.target[i_target]
+        id_wire = 2*(single_target-1)+1
+        circuit_layout[id_wire, i_step] = "--$(gate.display_symbol[i_target])--"
+    end
 end
 
 function print_circuit_layout(io, circuit_layout)


### PR DESCRIPTION
Drawing a circuit no longer fails when the difference between the control qubit ID and the target qubit ID is other than 0 or 1. This includes cases where the control qubit ID is greater than the target qubit ID.