### PR TITLE
Fix/replace incorrect gate operations

### DIFF
--- a/src/Snowflake.jl
+++ b/src/Snowflake.jl
@@ -61,6 +61,8 @@ export
     does_circuit_satisfy_qpu_connectivity,
     transpile,
 
+    apply_gate!,
+
     # Gates
     sigma_x,
     sigma_y,

--- a/src/Snowflake.jl
+++ b/src/Snowflake.jl
@@ -61,7 +61,6 @@ export
     does_circuit_satisfy_qpu_connectivity,
     transpile,
 
-    get_transformed_state,
     apply_gate!,
 
     # Gates

--- a/src/Snowflake.jl
+++ b/src/Snowflake.jl
@@ -61,6 +61,7 @@ export
     does_circuit_satisfy_qpu_connectivity,
     transpile,
 
+    get_transformed_state,
     apply_gate!,
 
     # Gates

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -251,13 +251,13 @@ function simulate(circuit::QuantumCircuit)
     ψ = fock(0, hilbert_space_size)
     for step in circuit.pipeline 
         for gate in step
-            apply_gate!(ψ, gate, circuit.qubit_count)
+            apply_gate_without_ket_size_check!(ψ, gate, circuit.qubit_count)
         end
     end
     return ψ
 end
 
-function apply_gate!(state::Ket, gate::Gate, qubit_count)
+function apply_gate_without_ket_size_check!(state::Ket, gate::Gate, qubit_count)
     b0 = get_b0_bases_list(gate, qubit_count)
     b1 = get_b1_bases_list(gate, qubit_count)
     temp_state = zeros(Complex, length(b1))

--- a/src/core/quantum_gate.jl
+++ b/src/core/quantum_gate.jl
@@ -36,12 +36,6 @@ function Base.show(io::IO, gate::Gate)
     println(io, "\ttargets: $(gate.target)")
 end
 
-function get_transformed_state(state::Ket, gate::Gate)
-    transformed_state = deepcopy(state)
-    apply_gate!(transformed_state, gate)
-    return transformed_state
-end
-
 function apply_gate!(state::Ket, gate::Gate)
     qubit_count = log2(length(state))
     if mod(qubit_count, 1) != 0
@@ -55,10 +49,6 @@ function apply_gate!(state::Ket, gate::Gate)
     Snowflake.apply_gate_without_ket_size_check!(state, gate, Int(qubit_count))
 end
 
-
-Base.kron(x::Gate, y::Gate) = kron(x.operator, y.operator)
-Base.kron(x::Gate, y::Operator) = kron(x.operator, y)
-Base.kron(x::Operator, y::Gate) = kron(x, y.operator)
 
 # Single Qubit Gates
 sigma_x() = Operator(reshape(Complex.([0.0, 1.0, 1.0, 0.0]), 2, 2))
@@ -127,7 +117,13 @@ control_x(control_qubit, target_qubit) =
     Gate(["*" "X"], "cx", control_x(), [control_qubit, target_qubit])
 iswap(qubit_1, qubit_2) = Gate(["x" "x"], "iswap", iswap(), [qubit_1, qubit_2])
 
-Base.:*(M::Gate, x::Ket) = M.operator * x
+Base.:*(M::Gate, x::Ket) = get_transformed_state(x, M)
+
+function get_transformed_state(state::Ket, gate::Gate)
+    transformed_state = deepcopy(state)
+    apply_gate!(transformed_state, gate)
+    return transformed_state
+end
 
 STD_GATES = Dict(
     "x" => sigma_x,

--- a/src/core/quantum_gate.jl
+++ b/src/core/quantum_gate.jl
@@ -36,6 +36,20 @@ function Base.show(io::IO, gate::Gate)
     println(io, "\ttargets: $(gate.target)")
 end
 
+function apply_gate!(state::Ket, gate::Gate)
+    qubit_count = log2(length(state))
+    if mod(qubit_count, 1) != 0
+        throw(DomainError(qubit_count,
+            "Ket does not correspond to an integer number of qubits"))
+    end
+    if any(i_target->(i_target>qubit_count), gate.target)
+        throw(DomainError(gate.target,
+            "not enough qubits in the Ket for the Gate"))
+    end
+    Snowflake.apply_gate_without_ket_size_check!(state, gate, Int(qubit_count))
+end
+
+
 Base.kron(x::Gate, y::Gate) = kron(x.operator, y.operator)
 Base.kron(x::Gate, y::Operator) = kron(x.operator, y)
 Base.kron(x::Operator, y::Gate) = kron(x, y.operator)

--- a/src/core/quantum_gate.jl
+++ b/src/core/quantum_gate.jl
@@ -36,6 +36,12 @@ function Base.show(io::IO, gate::Gate)
     println(io, "\ttargets: $(gate.target)")
 end
 
+function get_transformed_state(state::Ket, gate::Gate)
+    transformed_state = deepcopy(state)
+    apply_gate!(transformed_state, gate)
+    return transformed_state
+end
+
 function apply_gate!(state::Ket, gate::Gate)
     qubit_count = log2(length(state))
     if mod(qubit_count, 1) != 0

--- a/test/gate.jl
+++ b/test/gate.jl
@@ -14,6 +14,10 @@ using Test
 
     non_qubit_ket = Ket([1.0, 0.0, 0.0])
     @test_throws DomainError apply_gate!(non_qubit_ket, hadamard(1))
+
+    transformed_ψ_1 = get_transformed_state(ψ_1, hadamard(1))
+    @test ψ_1 ≈ fock(1,2)
+    @test transformed_ψ_1 ≈ 1/2^.5*(ψ_0-ψ_1)
 end
 
 

--- a/test/gate.jl
+++ b/test/gate.jl
@@ -15,7 +15,7 @@ using Test
     non_qubit_ket = Ket([1.0, 0.0, 0.0])
     @test_throws DomainError apply_gate!(non_qubit_ket, hadamard(1))
 
-    transformed_ψ_1 = get_transformed_state(ψ_1, hadamard(1))
+    transformed_ψ_1 = hadamard(1)*ψ_1
     @test ψ_1 ≈ fock(1,2)
     @test transformed_ψ_1 ≈ 1/2^.5*(ψ_0-ψ_1)
 end

--- a/test/gate.jl
+++ b/test/gate.jl
@@ -2,6 +2,21 @@ using Snowflake
 using Test
 
 
+@testset "apply_gate" begin
+    ψ_0 = fock(0,2)
+    ψ_0_to_update = fock(0,2)
+    ψ_1 = fock(1,2)
+
+    apply_gate!(ψ_0_to_update, hadamard(1))
+    @test ψ_0_to_update ≈ 1/2^.5*(ψ_0+ψ_1)
+
+    @test_throws DomainError apply_gate!(ψ_0_to_update, hadamard(2))
+
+    non_qubit_ket = Ket([1.0, 0.0, 0.0])
+    @test_throws DomainError apply_gate!(non_qubit_ket, hadamard(1))
+end
+
+
 @testset "gate_set" begin
     H = hadamard(1)
 


### PR DESCRIPTION
Added a function which applies a Gate to a Ket. The function ensures that the Ket has a valid length. The overloaded multiplication operator now works for all qubit targets.  Removed the Kronecker products which don't have a clear definition.