### PR TITLE
Feat/add measurement probabilities

### DIFF
--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -79,7 +79,7 @@ MultiBodySystem
 commute
 anticommute
 normalize!
-get_measurement_probabilities(x::Ket)
+get_measurement_probabilities(x::Ket{Complex{T}}) where T<:Real
 ket2dm
 fock_dm
 Snowflake.moyal

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -12,6 +12,7 @@ push_gate!
 pop_gate!
 simulate
 simulate_shots
+get_measurement_probabilities(circuit::QuantumCircuit)
 get_inverse(circuit::QuantumCircuit)
 get_gate_counts
 get_num_gates

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -78,6 +78,7 @@ MultiBodySystem
 commute
 anticommute
 normalize!
+get_measurement_probabilities(x::Ket)
 ket2dm
 fock_dm
 Snowflake.moyal

--- a/src/Snowflake.jl
+++ b/src/Snowflake.jl
@@ -50,6 +50,7 @@ export
     get_num_qubits,
     get_num_bodies,
     normalize!,
+    get_measurement_probabilities,
     wigner, 
     viz_wigner, 
     sesolve,

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -756,13 +756,13 @@ julia> get_measurement_probabilities(ψ, target_qubit)
 ```
 """
 function get_measurement_probabilities(x::Ket)
-    return real.(x .* x)
+    return real.(adjoint.(x) .* x)
 end
 
 function get_measurement_probabilities(x::Ket, target_bodies::Vector{<:Integer},
     hspace_size_per_body::Integer=2)
 
-    amplitudes = real.(x .* x)
+    amplitudes = real.(adjoint.(x) .* x)
     num_amplitudes = length(amplitudes)
     num_target_amplitudes = hspace_size_per_body^length(target_bodies)
     if num_target_amplitudes == num_amplitudes

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -766,7 +766,7 @@ function get_measurement_probabilities(x::Ket, target_bodies::Vector{<:Integer},
     num_amplitudes = length(amplitudes)
     num_target_amplitudes = hspace_size_per_body^length(target_bodies)
     if num_target_amplitudes == num_amplitudes
-        return get_measurement_probabilities(x)
+        return amplitudes
     else
         num_bodies = get_num_bodies(x, hspace_size_per_body)
         remaining_bodies = [x for x ∈ 1:num_bodies if x ∉ target_bodies]

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -759,8 +759,9 @@ function get_measurement_probabilities(x::Ket)
     return real.(adjoint.(x) .* x)
 end
 
-function get_measurement_probabilities(x::Ket, target_bodies::Vector{<:Integer},
-    hspace_size_per_body::Integer=2)
+function get_measurement_probabilities(x::Ket{Complex{T}},
+    target_bodies::Vector{U},
+    hspace_size_per_body::U=2) where {T<:Real, U<:Integer}
 
     amplitudes = real.(adjoint.(x) .* x)
     num_amplitudes = length(amplitudes)
@@ -770,7 +771,7 @@ function get_measurement_probabilities(x::Ket, target_bodies::Vector{<:Integer},
     else
         num_bodies = get_num_bodies(x, hspace_size_per_body)
         remaining_bodies = [x for x ∈ 1:num_bodies if x ∉ target_bodies]
-        target_amplitudes = Vector{Float64}(undef, num_target_amplitudes)
+        target_amplitudes = Vector{T}(undef, num_target_amplitudes)
         num_summed_amplitudes = hspace_size_per_body^length(remaining_bodies)
         for i_target_amplitude in 0:num_target_amplitudes-1
             sum = 0
@@ -785,10 +786,10 @@ function get_measurement_probabilities(x::Ket, target_bodies::Vector{<:Integer},
     end
 end
 
-function get_ket_index(target_bodies::Vector{<:Integer},
-    remaining_bodies::Vector{<:Integer},
-    hspace_size_per_body::Integer, target_index::Integer,
-    remainder_index::Integer)
+function get_ket_index(target_bodies::Vector{T},
+    remaining_bodies::Vector{T},
+    hspace_size_per_body::T, target_index::T,
+    remainder_index::T) where T<:Integer
 
     target_symbols = change_number_base(target_index, hspace_size_per_body,
         length(target_bodies))
@@ -806,10 +807,10 @@ function get_ket_index(target_bodies::Vector{<:Integer},
     return decimal+1
 end
 
-function change_number_base(decimal::Integer, base::Integer, num_symbols::Integer)
+function change_number_base(decimal::T, base::T, num_symbols::T) where T<:Integer
     throw_if_number_base_cannot_be_changed(decimal, base, num_symbols)
     dividend = decimal
-    symbols = zeros(Int, num_symbols)
+    symbols = zeros(T, num_symbols)
     count = 0
     while dividend != 0
         (dividend, remainder) = fldmod(dividend, base)

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -709,6 +709,63 @@ function normalize!(x::Ket)
     return x
 end
 
+# function get_measurement_probabilities(x::Ket)
+#     return real.(x .* x)
+# end
+
+# function get_measurement_probabilities(x::Ket, target_bodies::Vector{<:Integer},
+#     hilbert_space_size_per_body::Integer=2)
+
+#     amplitudes = real.(x .* x)
+#     num_amplitudes = length(amplitudes)
+#     num_target_amplitudes = hilbert_space_size_per_body^length(target_bodies)
+#     if num_target_amplitudes > num_amplitudes
+#         throw(ErrorException("too many target bodies were provided"))
+#     elseif num_target_amplitudes == num_amplitudes
+#         return get_measurement_probabilities(x)
+#     else
+#         target_amplitudes = Vector{Float64}(undef, num_target_amplitudes)
+#         num_summed_amplitudes = num_amplitudes-num_target_amplitudes
+#         for i_target_amplitude in 1:num_target_amplitudes
+#             for i_summed_amplitude in 1:num_summed_amplitudes
+
+#             end
+#         end
+#     end
+# end
+
+# function get_ket_index(target_bodies::Vector{<:Integer},
+#     hilbert_space_size_per_body::Integer, target_index::Integer,
+#     remainder_index::Integer)
+
+
+# end
+
+function change_number_base(decimal::Integer, base::Integer, num_symbols::Integer)
+    throw_if_number_base_cannot_be_changed(decimal, base, num_symbols)
+    dividend = decimal
+    symbols = zeros(Int, num_symbols)
+    count = 0
+    while dividend != 0
+        (dividend, remainder) = fldmod(dividend, base)
+        symbols[end-count] = remainder
+        count += 1
+    end
+    return symbols
+end
+
+function throw_if_number_base_cannot_be_changed(decimal::Integer, base::Integer,
+    num_symbols::Integer)
+    
+    if decimal < 0
+        throw(ErrorException("the decimal cannot be negative"))
+    elseif decimal >= base^num_symbols
+        min_num_symbols = Int(ceil(log2(decimal+1)/log2(base)))
+        throw(ErrorException(
+            "the decimal $decimal needs at least $min_num_symbols symbols"))
+    end
+end
+
 """
     Snowflake.commute(A::Operator, B::Operator)
 

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -726,32 +726,34 @@ end
 #     else
 #         target_amplitudes = Vector{Float64}(undef, num_target_amplitudes)
 #         num_summed_amplitudes = num_amplitudes-num_target_amplitudes
-#         for i_target_amplitude in 1:num_target_amplitudes
-#             for i_summed_amplitude in 1:num_summed_amplitudes
+#         for i_target_amplitude in 0:num_target_amplitudes-1
+#             for i_summed_amplitude in 0:num_summed_amplitudes-1
 
 #             end
 #         end
 #     end
 # end
 
-# function get_ket_index(target_bodies::Vector{<:Integer},
-#     remaining_bodies::Vector{<:Integer},
-#     hilbert_space_size_per_body::Integer, target_index::Integer,
-#     remainder_index::Integer)
+function get_ket_index(target_bodies::Vector{<:Integer},
+    remaining_bodies::Vector{<:Integer},
+    hilbert_space_size_per_body::Integer, target_index::Integer,
+    remainder_index::Integer)
 
-#     target_symbols = change_number_base(target_index, hilbert_space_size_per_body,
-#         length(target_bodies))
-#     remainder_symbols = change_number_base(remainder_index, hilbert_space_size_per_body,
-#         length(remaining_bodies))
-#     num_symbols = length(target_bodies)+length(remaining_bodies)
-#     combined_symbols = Vector{Int}(undef, num_symbols)
-#     for (i_target, target) in enumerate(target_bodies)
-#         combined_symbols[target] = target_symbols[i_target]
-#     end
-#     for (i_remaining, remaining) in enumerate(target_bodies)
-#         combined_symbols[remaining] = remainder_symbols[i_remaining]
-#     end
-# end
+    target_symbols = change_number_base(target_index, hilbert_space_size_per_body,
+        length(target_bodies))
+    remainder_symbols = change_number_base(remainder_index, hilbert_space_size_per_body,
+        length(remaining_bodies))
+    num_symbols = length(target_bodies)+length(remaining_bodies)
+    combined_symbols = Vector{Int}(undef, num_symbols)
+    for (i_target, target) in enumerate(target_bodies)
+        combined_symbols[target] = target_symbols[i_target]
+    end
+    for (i_remaining, remaining) in enumerate(remaining_bodies)
+        combined_symbols[remaining] = remainder_symbols[i_remaining]
+    end
+    ket_index = change_to_decimal_integer(combined_symbols, hilbert_space_size_per_body)
+    return ket_index
+end
 
 function change_number_base(decimal::Integer, base::Integer, num_symbols::Integer)
     throw_if_number_base_cannot_be_changed(decimal, base, num_symbols)

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -690,6 +690,7 @@ end
 
 Normalizes Ket `x` such that its magnitude becomes unity.
 
+```jldoctest
 julia> ψ=Ket([1.,2.,4.])
 3-element Ket{ComplexF64}:
 1.0 + 0.0im
@@ -701,6 +702,7 @@ julia> normalize!(ψ)
 0.2182178902359924 + 0.0im
 0.4364357804719848 + 0.0im
 0.8728715609439696 + 0.0im
+```
 
 """
 function normalize!(x::Ket)
@@ -710,14 +712,17 @@ function normalize!(x::Ket)
 end
 
 """
-    get_measurement_probabilities(x::Ket, [target_bodies::Vector{<:Integer},
-        hspace_size_per_body::Integer=2])
+    get_measurement_probabilities(x::Ket{Complex{T}},
+        [target_bodies::Vector{U},
+        hspace_size_per_body::Union{U,Vector{U}}=2])::AbstractVector{T}
+        where {T<:Real, U<:Integer}
 
 Returns a vector listing the measurement probabilities of the `target_bodies` of `Ket` `x`.
 
-The Hilbert space size per body can be specified by providing a value for the
-`hspace_size_per_body` argument. If only `x` is provided, the probabilities are provided for
-all the bodies.
+The Hilbert space size per body can be specified by providing a `Vector` of `Integer` for
+the `hspace_size_per_body` argument. The `Vector` must specify the Hilbert space size for
+each body. If the space size is uniform, a single `Integer` can be given instead. If
+only `x` is provided, the probabilities are provided for all the bodies.
 
 The measurement probabilities are listed from the smallest to the largest computational
 basis state. For instance, for a 2-qubit `Ket`, the probabilities are listed for 00, 01, 10,
@@ -726,14 +731,13 @@ and 11.
 The following example constructs a `Ket`, where the probability of measuring 00 is 50% and
 the probability of measuring 10 is also 50%.
 ```jldoctest get_measurement_probabilities
-julia> ψ = 1/sqrt(2)*Ket([1, 0, 1, 0]);
+julia> ψ = 1/sqrt(2)*Ket([1, 0, 1, 0])
+4-element Ket{ComplexF64}:
+0.7071067811865475 + 0.0im
+0.0 + 0.0im
+0.7071067811865475 + 0.0im
+0.0 + 0.0im
 
-julia> print(ψ)
-4-element Ket:
-0.7071067811865475 + 0.0im
-0.0 + 0.0im
-0.7071067811865475 + 0.0im
-0.0 + 0.0im
 
 julia> get_measurement_probabilities(ψ)
 4-element Vector{Float64}:

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -735,10 +735,22 @@ end
 # end
 
 # function get_ket_index(target_bodies::Vector{<:Integer},
+#     remaining_bodies::Vector{<:Integer},
 #     hilbert_space_size_per_body::Integer, target_index::Integer,
 #     remainder_index::Integer)
 
-
+#     target_symbols = change_number_base(target_index, hilbert_space_size_per_body,
+#         length(target_bodies))
+#     remainder_symbols = change_number_base(remainder_index, hilbert_space_size_per_body,
+#         length(remaining_bodies))
+#     num_symbols = length(target_bodies)+length(remaining_bodies)
+#     combined_symbols = Vector{Int}(undef, num_symbols)
+#     for (i_target, target) in enumerate(target_bodies)
+#         combined_symbols[target] = target_symbols[i_target]
+#     end
+#     for (i_remaining, remaining) in enumerate(target_bodies)
+#         combined_symbols[remaining] = remainder_symbols[i_remaining]
+#     end
 # end
 
 function change_number_base(decimal::Integer, base::Integer, num_symbols::Integer)
@@ -764,6 +776,16 @@ function throw_if_number_base_cannot_be_changed(decimal::Integer, base::Integer,
         throw(ErrorException(
             "the decimal $decimal needs at least $min_num_symbols symbols"))
     end
+end
+
+function change_to_decimal_integer(symbols::Vector{<:Integer}, base::Integer)
+    decimal = 0
+    num_symbols = length(symbols)
+    for (i_symbol, digit) in enumerate(symbols)
+        power = num_symbols-i_symbol
+        decimal += digit*base^power
+    end
+    return decimal
 end
 
 """

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -709,28 +709,74 @@ function normalize!(x::Ket)
     return x
 end
 
+"""
+    get_measurement_probabilities(x::Ket, [target_bodies::Vector{<:Integer},
+        hspace_size_per_body::Integer=2])
+
+Returns a vector listing the measurement probabilities of the `target_bodies` of `Ket` `x`.
+
+The Hilbert space size per body can be specified by providing a value for the
+`hspace_size_per_body` argument. If only `x` is provided, the probabilities are provided for
+all the bodies.
+
+The measurement probabilities are listed from the smallest to the largest computational
+basis state. For instance, for a 2-qubit `Ket`, the probabilities are listed for 00, 01, 10,
+and 11.
+# Examples
+The following example constructs a `Ket`, where the probability of measuring 00 is 50% and
+the probability of measuring 10 is also 50%.
+```jldoctest get_measurement_probabilities
+julia> ψ = 1/sqrt(2)*Ket([1, 0, 1, 0]);
+
+julia> print(ψ)
+4-element Ket:
+0.7071067811865475 + 0.0im
+0.0 + 0.0im
+0.7071067811865475 + 0.0im
+0.0 + 0.0im
+
+julia> get_measurement_probabilities(ψ)
+4-element Vector{Float64}:
+ 0.4999999999999999
+ 0.0
+ 0.4999999999999999
+ 0.0
+
+```
+
+For the same `Ket`, the probability of measuring qubit 2 and finding 0 is 100%.
+```jldoctest get_measurement_probabilities
+julia> target_qubit = [2];
+
+julia> get_measurement_probabilities(ψ, target_qubit)
+2-element Vector{Float64}:
+ 0.9999999999999998
+ 0.0
+
+```
+"""
 function get_measurement_probabilities(x::Ket)
     return real.(x .* x)
 end
 
 function get_measurement_probabilities(x::Ket, target_bodies::Vector{<:Integer},
-    hilbert_space_size_per_body::Integer=2)
+    hspace_size_per_body::Integer=2)
 
     amplitudes = real.(x .* x)
     num_amplitudes = length(amplitudes)
-    num_target_amplitudes = hilbert_space_size_per_body^length(target_bodies)
+    num_target_amplitudes = hspace_size_per_body^length(target_bodies)
     if num_target_amplitudes == num_amplitudes
         return get_measurement_probabilities(x)
     else
-        num_bodies = get_num_bodies(x, hilbert_space_size_per_body)
+        num_bodies = get_num_bodies(x, hspace_size_per_body)
         remaining_bodies = [x for x ∈ 1:num_bodies if x ∉ target_bodies]
         target_amplitudes = Vector{Float64}(undef, num_target_amplitudes)
-        num_summed_amplitudes = hilbert_space_size_per_body^length(remaining_bodies)
+        num_summed_amplitudes = hspace_size_per_body^length(remaining_bodies)
         for i_target_amplitude in 0:num_target_amplitudes-1
             sum = 0
             for i_summed_amplitude in 0:num_summed_amplitudes-1
                 ket_index = get_ket_index(target_bodies, remaining_bodies,
-                    hilbert_space_size_per_body, i_target_amplitude, i_summed_amplitude)
+                    hspace_size_per_body, i_target_amplitude, i_summed_amplitude)
                 sum += amplitudes[ket_index]
             end
             target_amplitudes[i_target_amplitude+1] = sum
@@ -741,12 +787,12 @@ end
 
 function get_ket_index(target_bodies::Vector{<:Integer},
     remaining_bodies::Vector{<:Integer},
-    hilbert_space_size_per_body::Integer, target_index::Integer,
+    hspace_size_per_body::Integer, target_index::Integer,
     remainder_index::Integer)
 
-    target_symbols = change_number_base(target_index, hilbert_space_size_per_body,
+    target_symbols = change_number_base(target_index, hspace_size_per_body,
         length(target_bodies))
-    remainder_symbols = change_number_base(remainder_index, hilbert_space_size_per_body,
+    remainder_symbols = change_number_base(remainder_index, hspace_size_per_body,
         length(remaining_bodies))
     num_symbols = length(target_bodies)+length(remaining_bodies)
     combined_symbols = Vector{Int}(undef, num_symbols)
@@ -756,7 +802,7 @@ function get_ket_index(target_bodies::Vector{<:Integer},
     for (i_remaining, remaining) in enumerate(remaining_bodies)
         combined_symbols[remaining] = remainder_symbols[i_remaining]
     end
-    decimal = change_to_decimal_integer(combined_symbols, hilbert_space_size_per_body)
+    decimal = change_to_decimal_integer(combined_symbols, hspace_size_per_body)
     return decimal+1
 end
 

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -755,13 +755,13 @@ julia> get_measurement_probabilities(ψ, target_qubit)
 
 ```
 """
-function get_measurement_probabilities(x::Ket)
+function get_measurement_probabilities(x::Ket{Complex{T}})::AbstractVector{T} where T<:Real
     return real.(adjoint.(x) .* x)
 end
 
 function get_measurement_probabilities(x::Ket{Complex{T}},
     target_bodies::Vector{U},
-    hspace_size_per_body::U = 2) where {T<:Real, U<:Integer}
+    hspace_size_per_body::U = 2)::AbstractVector{T} where {T<:Real, U<:Integer}
 
     num_bodies = get_num_bodies(x, hspace_size_per_body)
     hspace_size_per_body_list = fill(hspace_size_per_body, num_bodies)
@@ -770,7 +770,7 @@ end
 
 function get_measurement_probabilities(x::Ket{Complex{T}},
     target_bodies::Vector{U},
-    hspace_size_per_body::Vector{U}) where {T<:Real, U<:Integer}
+    hspace_size_per_body::Vector{U})::AbstractVector{T} where {T<:Real, U<:Integer}
 
     throw_if_targets_are_invalid(x, target_bodies, hspace_size_per_body)
     amplitudes = real.(adjoint.(x) .* x)

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -761,6 +761,15 @@ end
 
 function get_measurement_probabilities(x::Ket{Complex{T}},
     target_bodies::Vector{U},
+    hspace_size_per_body::U = 2) where {T<:Real, U<:Integer}
+
+    num_bodies = get_num_bodies(x, hspace_size_per_body)
+    hspace_size_per_body_list = fill(hspace_size_per_body, num_bodies)
+    return get_measurement_probabilities(x, target_bodies, hspace_size_per_body_list)
+end
+
+function get_measurement_probabilities(x::Ket{Complex{T}},
+    target_bodies::Vector{U},
     hspace_size_per_body::Vector{U}) where {T<:Real, U<:Integer}
 
     amplitudes = real.(adjoint.(x) .* x)

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -777,7 +777,7 @@ function get_measurement_probabilities(x::Ket{Complex{T}},
     hspace_size_per_body::Vector{U})::AbstractVector{T} where {T<:Real, U<:Integer}
 
     throw_if_targets_are_invalid(x, target_bodies, hspace_size_per_body)
-    amplitudes = real.(adjoint.(x) .* x)
+    amplitudes = get_measurement_probabilities(x)
     num_amplitudes = length(amplitudes)
     num_target_amplitudes = get_num_target_amplitudes(target_bodies, hspace_size_per_body)
     if num_target_amplitudes == num_amplitudes

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -553,13 +553,13 @@ julia> get_measurement_probabilities(circuit, target_qubit)
 
 ```
 """
-function get_measurement_probabilities(circuit::QuantumCircuit)
+function get_measurement_probabilities(circuit::QuantumCircuit)::AbstractVector{<:Real}
     ket = simulate(circuit)
     return get_measurement_probabilities(ket)
 end
 
 function get_measurement_probabilities(circuit::QuantumCircuit,
-    target_qubits::Vector{<:Integer})
+    target_qubits::Vector{<:Integer})::AbstractVector{<:Real}
     
     ket = simulate(circuit)
     return get_measurement_probabilities(ket, target_qubits)

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -504,6 +504,18 @@ function simulate_shots(c::QuantumCircuit, shots_count::Int = 100)
     return data
 end
 
+function get_measurement_probabilities(circuit::QuantumCircuit)
+    ket = simulate(circuit)
+    return get_measurement_probabilities(ket)
+end
+
+function get_measurement_probabilities(circuit::QuantumCircuit,
+    target_qubit::Vector{<:Integer})
+    
+    ket = simulate(circuit)
+    return get_measurement_probabilities(ket, target_qubit)
+end
+
 """
     get_inverse(circuit::QuantumCircuit)
 

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -484,7 +484,7 @@ julia> simulate_shots(c, 99)
 function simulate_shots(c::QuantumCircuit, shots_count::Int = 100)
     # return simulateShots(c, shots_count)
     ψ = simulate(c)
-    amplitudes = real.(ψ .* ψ)
+    amplitudes = adjoint.(ψ) .* ψ
     weights = Float32[]
 
     for a in amplitudes

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -504,16 +504,65 @@ function simulate_shots(c::QuantumCircuit, shots_count::Int = 100)
     return data
 end
 
+"""
+    get_measurement_probabilities(circuit::QuantumCircuit,
+        [target_qubits::Vector{<:Integer}])
+
+Returns a vector listing the measurement probabilities for the `target_qubits` in the `circuit`.
+
+If no `target_qubits` are provided, the probabilities are computed for all the qubits.
+
+The measurement probabilities are listed from the smallest to the largest computational
+basis state. For instance, for a 2-qubit `QuantumCircuit`, the probabilities are listed
+for 00, 01, 10, and 11.
+# Examples
+The following example constructs a `QuantumCircuit` where the probability of measuring 01
+is 50% and the probability of measuring 11 is also 50%.
+```jldoctest get_circuit_measurement_probabilities
+julia> circuit = QuantumCircuit(qubit_count=2, bit_count=0);
+
+julia> push_gate!(circuit, [hadamard(1), sigma_x(2)])
+Quantum Circuit Object:
+   id: 43eb23ac-8d4b-11ed-0419-f390b8ec7cef 
+   qubit_count: 2 
+   bit_count: 0 
+q[1]:──H──
+          
+q[2]:──X──
+          
+
+
+
+julia> get_measurement_probabilities(circuit)
+4-element Vector{Float64}:
+ 0.0
+ 0.4999999999999999
+ 0.0
+ 0.4999999999999999
+
+```
+
+For the same `circuit`, the probability of measuring qubit 2 and finding 1 is 100%.
+```jldoctest get_circuit_measurement_probabilities
+julia> target_qubit = [2];
+
+julia> get_measurement_probabilities(circuit, target_qubit)
+2-element Vector{Float64}:
+ 0.0
+ 0.9999999999999998
+
+```
+"""
 function get_measurement_probabilities(circuit::QuantumCircuit)
     ket = simulate(circuit)
     return get_measurement_probabilities(ket)
 end
 
 function get_measurement_probabilities(circuit::QuantumCircuit,
-    target_qubit::Vector{<:Integer})
+    target_qubits::Vector{<:Integer})
     
     ket = simulate(circuit)
-    return get_measurement_probabilities(ket, target_qubit)
+    return get_measurement_probabilities(ket, target_qubits)
 end
 
 """

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -506,7 +506,7 @@ end
 
 """
     get_measurement_probabilities(circuit::QuantumCircuit,
-        [target_qubits::Vector{<:Integer}])
+        [target_qubits::Vector{<:Integer}])::AbstractVector{<:Real}
 
 Returns a vector listing the measurement probabilities for the `target_qubits` in the `circuit`.
 

--- a/test/circuit.jl
+++ b/test/circuit.jl
@@ -55,6 +55,17 @@ end
     @test ~("01" in readings)
 end
 
+@testset "global_phase" begin
+    circuit = QuantumCircuit(qubit_count=1, bit_count=0)
+    push_gate!(circuit, sigma_x(1))
+    push_gate!(circuit, phase(1))
+    push_gate!(circuit, sigma_x(1))
+    push_gate!(circuit, phase(1))
+    shots = simulate_shots(circuit, 5)
+    @test ("0" in shots)
+    @test ~("1" in shots)
+end
+
 @testset "phase_kickback" begin
 
     Ψ_up = spin_up()

--- a/test/circuit.jl
+++ b/test/circuit.jl
@@ -118,3 +118,18 @@ end
     depth = get_logical_depth(c)
     @test depth == 3
 end
+
+@testset "get_measurement_probabilities" begin
+    circuit = QuantumCircuit(qubit_count=2, bit_count=0)
+    push_gate!(circuit, [hadamard(1), sigma_x(2)])
+    probabilities = get_measurement_probabilities(circuit)
+    @test probabilities ≈ [0, 0.5, 0, 0.5]
+
+    target_qubit = [1]
+    probabilities = get_measurement_probabilities(circuit, target_qubit)
+    @test probabilities ≈ [0.5, 0.5]
+
+    target_qubit = [2]
+    probabilities = get_measurement_probabilities(circuit, target_qubit)
+    @test probabilities ≈ [0, 1]
+end

--- a/test/qobj.jl
+++ b/test/qobj.jl
@@ -183,3 +183,10 @@ end
     expected_symbols = [0, 1, 2, 1]
     @test symbols == expected_symbols
 end
+
+@testset "change_to_decimal_integer" begin
+    symbols = [0, 1, 2, 1]
+    base = 3
+    decimal = Snowflake.change_to_decimal_integer(symbols, base)
+    @test decimal == 16
+end

--- a/test/qobj.jl
+++ b/test/qobj.jl
@@ -168,3 +168,18 @@ end
     @test is_hermitian(sigma_y())
     @test !is_hermitian(sigma_p())
 end
+
+@testset "change_number_base" begin
+    decimal = -1
+    base = 3
+    num_symbols = 4
+    @test_throws ErrorException Snowflake.change_number_base(decimal, base, num_symbols)
+    
+    decimal = 88
+    @test_throws ErrorException Snowflake.change_number_base(decimal, base, num_symbols)
+
+    decimal = 16
+    symbols = Snowflake.change_number_base(decimal, base, num_symbols)
+    expected_symbols = [0, 1, 2, 1]
+    @test symbols == expected_symbols
+end

--- a/test/qobj.jl
+++ b/test/qobj.jl
@@ -199,5 +199,25 @@ end
     remainder_index = 1
     ket_index = Snowflake.get_ket_index(target_bodies, remaining_bodies, base,
         target_index, remainder_index)
-    @test ket_index == 21
+    @test ket_index == 22
+end
+
+@testset "get_measurement_probabilities" begin
+    ket = 1/sqrt(5)*Ket([1, 0, 1, 0, 0, 1, 1, 1, 0])
+    probabilities = get_measurement_probabilities(ket)
+    @test probabilities ≈ [0.2, 0, 0.2, 0, 0, 0.2, 0.2, 0.2, 0]
+
+    target_bodies = [1, 2]
+    base = 3
+    probabilities = get_measurement_probabilities(ket, target_bodies, base)
+    @test probabilities ≈ [0.2, 0, 0.2, 0, 0, 0.2, 0.2, 0.2, 0]
+
+    target_bodies = [1]
+    probabilities = get_measurement_probabilities(ket, target_bodies, base)
+    @test probabilities ≈ [0.4, 0.2, 0.4]
+
+    ket = 1/2*Ket([0, 1, 1, 0, 0, 1, 0, 1])
+    target_bodies = [1, 3]
+    probabilities = get_measurement_probabilities(ket, target_bodies)
+    @test probabilities ≈ [0.25, 0.25, 0, 0.5]
 end

--- a/test/qobj.jl
+++ b/test/qobj.jl
@@ -179,6 +179,10 @@ end
     probabilities = get_measurement_probabilities(ket, target_bodies, hspace_size_per_body)
     @test probabilities ≈ 1/5*[2, 1, 2]
 
+    target_bodies = [1,2]
+    probabilities = get_measurement_probabilities(ket, target_bodies, hspace_size_per_body)
+    @test probabilities ≈ [0.2, 0, 0.2, 0, 0, 0.2, 0.2, 0.2, 0]
+
     ket = 1/sqrt(3)*Ket([1, 0, -im, 1])
     target_bodies = [1]
     probabilities = get_measurement_probabilities(ket, target_bodies)
@@ -189,4 +193,24 @@ end
     hspace_size_per_body = [2, 3, 2]
     probabilities = get_measurement_probabilities(ket, target_bodies, hspace_size_per_body)
     @test probabilities ≈ 1/7*[1, 1, 1, 2, 1, 1]
+
+    wrong_hspace_size_per_body = Int[]
+    @test_throws ErrorException get_measurement_probabilities(ket, target_bodies,
+        wrong_hspace_size_per_body)
+
+    not_unique_targets = [1, 1]
+    @test_throws ErrorException get_measurement_probabilities(ket, not_unique_targets,
+        hspace_size_per_body)
+
+    unsorted_targets = [2, 1]
+    @test_throws ErrorException get_measurement_probabilities(ket, unsorted_targets,
+        hspace_size_per_body)
+
+    large_targets = [1, 4]
+    @test_throws ErrorException get_measurement_probabilities(ket, large_targets,
+        hspace_size_per_body)
+
+    empty_target_bodies = Int[]
+    @test_throws ErrorException get_measurement_probabilities(ket, empty_target_bodies,
+        hspace_size_per_body)
 end

--- a/test/qobj.jl
+++ b/test/qobj.jl
@@ -190,3 +190,14 @@ end
     decimal = Snowflake.change_to_decimal_integer(symbols, base)
     @test decimal == 16
 end
+
+@testset "get_ket_index" begin
+    target_bodies = [1, 3]
+    remaining_bodies = [2]
+    base = 3
+    target_index = 6
+    remainder_index = 1
+    ket_index = Snowflake.get_ket_index(target_bodies, remaining_bodies, base,
+        target_index, remainder_index)
+    @test ket_index == 21
+end

--- a/test/qobj.jl
+++ b/test/qobj.jl
@@ -169,55 +169,14 @@ end
     @test !is_hermitian(sigma_p())
 end
 
-@testset "change_number_base" begin
-    decimal = -1
-    base = 3
-    num_symbols = 4
-    @test_throws ErrorException Snowflake.change_number_base(decimal, base, num_symbols)
-    
-    decimal = 88
-    @test_throws ErrorException Snowflake.change_number_base(decimal, base, num_symbols)
-
-    decimal = 16
-    symbols = Snowflake.change_number_base(decimal, base, num_symbols)
-    expected_symbols = [0, 1, 2, 1]
-    @test symbols == expected_symbols
-end
-
-@testset "change_to_decimal_integer" begin
-    symbols = [0, 1, 2, 1]
-    base = 3
-    decimal = Snowflake.change_to_decimal_integer(symbols, base)
-    @test decimal == 16
-end
-
-@testset "get_ket_index" begin
-    target_bodies = [1, 3]
-    remaining_bodies = [2]
-    base = 3
-    target_index = 6
-    remainder_index = 1
-    ket_index = Snowflake.get_ket_index(target_bodies, remaining_bodies, base,
-        target_index, remainder_index)
-    @test ket_index == 22
-end
-
 @testset "get_measurement_probabilities" begin
     ket = 1/sqrt(5)*Ket([1, 0, -im, 0, 0, im, -1, 1, 0])
     probabilities = get_measurement_probabilities(ket)
     @test probabilities ≈ [0.2, 0, 0.2, 0, 0, 0.2, 0.2, 0.2, 0]
 
+    ket = 1/sqrt(7)*Ket([1, 0, -im, 0, 0, im, -1, 1, 0, 1, 1, 0])
     target_bodies = [1, 2]
-    base = 3
-    probabilities = get_measurement_probabilities(ket, target_bodies, base)
-    @test probabilities ≈ [0.2, 0, 0.2, 0, 0, 0.2, 0.2, 0.2, 0]
-
-    target_bodies = [1]
-    probabilities = get_measurement_probabilities(ket, target_bodies, base)
-    @test probabilities ≈ [0.4, 0.2, 0.4]
-
-    ket = 1/2*Ket([0, -im, im, 0, 0, 1, 0, -1])
-    target_bodies = [1, 3]
-    probabilities = get_measurement_probabilities(ket, target_bodies)
-    @test probabilities ≈ [0.25, 0.25, 0, 0.5]
+    hspace_size_per_body = [2, 3, 2]
+    probabilities = get_measurement_probabilities(ket, target_bodies, hspace_size_per_body)
+    @test probabilities ≈ 1/7*[1, 1, 1, 2, 1, 1]
 end

--- a/test/qobj.jl
+++ b/test/qobj.jl
@@ -174,6 +174,16 @@ end
     probabilities = get_measurement_probabilities(ket)
     @test probabilities ≈ [0.2, 0, 0.2, 0, 0, 0.2, 0.2, 0.2, 0]
 
+    target_bodies = [2]
+    hspace_size_per_body = 3
+    probabilities = get_measurement_probabilities(ket, target_bodies, hspace_size_per_body)
+    @test probabilities ≈ 1/5*[2, 1, 2]
+
+    ket = 1/sqrt(3)*Ket([1, 0, -im, 1])
+    target_bodies = [1]
+    probabilities = get_measurement_probabilities(ket, target_bodies)
+    @test probabilities ≈ [1/3, 2/3]
+
     ket = 1/sqrt(7)*Ket([1, 0, -im, 0, 0, im, -1, 1, 0, 1, 1, 0])
     target_bodies = [1, 2]
     hspace_size_per_body = [2, 3, 2]

--- a/test/qobj.jl
+++ b/test/qobj.jl
@@ -203,7 +203,7 @@ end
 end
 
 @testset "get_measurement_probabilities" begin
-    ket = 1/sqrt(5)*Ket([1, 0, 1, 0, 0, 1, 1, 1, 0])
+    ket = 1/sqrt(5)*Ket([1, 0, -im, 0, 0, im, -1, 1, 0])
     probabilities = get_measurement_probabilities(ket)
     @test probabilities ≈ [0.2, 0, 0.2, 0, 0, 0.2, 0.2, 0.2, 0]
 
@@ -216,7 +216,7 @@ end
     probabilities = get_measurement_probabilities(ket, target_bodies, base)
     @test probabilities ≈ [0.4, 0.2, 0.4]
 
-    ket = 1/2*Ket([0, 1, 1, 0, 0, 1, 0, 1])
+    ket = 1/2*Ket([0, -im, im, 0, 0, 1, 0, -1])
     target_bodies = [1, 3]
     probabilities = get_measurement_probabilities(ket, target_bodies)
     @test probabilities ≈ [0.25, 0.25, 0, 0.5]


### PR DESCRIPTION
Adds functions for computing the measurement probabilities of a ket or a circuit. Probabilities for a subset of qubits can also be determined.

Fixes #43 and fixes #59.