### PR TITLE
Feat/add operator exponential

### DIFF
--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -65,6 +65,7 @@ Bra
 Operator
 Base.adjoint
 is_hermitian
+Base.exp(A::Operator)
 Base.getindex(A::Operator, m::Int64, n::Int64)
 eigen
 tr

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -184,6 +184,29 @@ Base.:+(A::Operator, B::Operator) = Operator(A.data+ B.data)
 Base.:-(A::Operator, B::Operator) = Operator(A.data- B.data)
 Base.length(x::Union{Ket, Bra}) = length(x.data)
 
+"""
+    exp(A::Operator)
+
+Compute the matrix exponential of `Operator` `A`.
+
+# Examples
+```jldoctest
+julia> X = sigma_x()
+(2, 2)-element Snowflake.Operator:
+Underlying data Matrix{ComplexF64}:
+0.0 + 0.0im    1.0 + 0.0im
+1.0 + 0.0im    0.0 + 0.0im
+
+
+julia> x_rotation_90_deg = exp(-im*π/4*X)
+(2, 2)-element Snowflake.Operator:
+Underlying data Matrix{ComplexF64}:
+0.7071067811865477 + 0.0im    0.0 - 0.7071067811865475im
+0.0 - 0.7071067811865475im    0.7071067811865477 + 0.0im
+
+
+```
+"""
 Base.exp(A::Operator) = Operator(exp(A.data))
 
 """

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -17,10 +17,8 @@ julia> ψ = Snowflake.Ket([1.0; 0.0; 0.0])
 ```
 A better way to initialize a Ket is to use a pre-built basis such as the `fock` basis. See [`fock`](@ref) for further information on this function. 
 ```jldoctest
-julia> ψ = Snowflake.fock(2, 3);
-
-julia> print(ψ)
-3-element Ket:
+julia> ψ = Snowflake.fock(2, 3)
+3-element Ket{ComplexF64}:
 0.0 + 0.0im
 0.0 + 0.0im
 1.0 + 0.0im
@@ -54,17 +52,18 @@ A structure representing a Bra (i.e. a row vector of complex values). A Bra is c
 - `data` -- the stored values.
 # Examples
 ```jldoctest
-julia> ψ = Snowflake.fock(1, 3);
-
-julia> print(ψ)
-3-element Ket:
+julia> ψ = Snowflake.fock(1, 3)
+3-element Ket{ComplexF64}:
 0.0 + 0.0im
 1.0 + 0.0im
 0.0 + 0.0im
 
 
-julia> print(_ψ)
-Bra(Any[0.0 - 0.0im 1.0 - 0.0im 0.0 - 0.0im])
+julia> _ψ = Snowflake.Bra(ψ)
+3-element Bra{ComplexF64}:
+0.0 - 0.0im
+1.0 - 0.0im
+0.0 - 0.0im
 
 
 julia> _ψ * ψ    # A Bra times a Ket is a scalar
@@ -275,10 +274,8 @@ Compute the expectation value ⟨`ψ`|`A`|`ψ`⟩ given Operator `A` and Ket |`�
 
 # Examples
 ```jldoctest
-julia> ψ = Ket([0.0; 1.0]);
-
-julia> print(ψ)
-2-element Ket:
+julia> ψ = Ket([0.0; 1.0])
+2-element Ket{ComplexF64}:
 0.0 + 0.0im
 1.0 + 0.0im
 
@@ -312,26 +309,20 @@ More details about the Kronecker product can be found
 
 # Examples
 ```jldoctest
-julia> ψ_0 = Ket([0.0; 1.0]);
-
-julia> print(ψ_0)
-2-element Ket:
+julia> ψ_0 = Ket([0.0; 1.0])
+2-element Ket{ComplexF64}:
 0.0 + 0.0im
 1.0 + 0.0im
 
 
-julia> ψ_1 = Ket([1.0; 0.0]);
-
-julia> print(ψ_1)
-2-element Ket:
+julia> ψ_1 = Ket([1.0; 0.0])
+2-element Ket{ComplexF64}:
 1.0 + 0.0im
 0.0 + 0.0im
 
 
-julia> ψ_0_1 = kron(ψ_0, ψ_1);
-
-julia> print(ψ_0_1)
-4-element Ket:
+julia> ψ_0_1 = kron(ψ_0, ψ_1)
+4-element Ket{ComplexF64}:
 0.0 + 0.0im
 0.0 + 0.0im
 1.0 + 0.0im
@@ -580,22 +571,25 @@ end
 Returns the `i`th fock basis of a Hilbert space with size `hspace_size` as Snowflake.Ket, of default type ComplexF64.
 # Examples
 ```jldoctest
-julia> ψ = Snowflake.fock(0, 3);
-
-julia> print(ψ)
-3-element Ket:
+julia> ψ = Snowflake.fock(0, 3)
+3-element Ket{ComplexF64}:
 1.0 + 0.0im
 0.0 + 0.0im
 0.0 + 0.0im
 
 
-julia> ψ = Snowflake.fock(1, 3);
-
-julia> print(ψ)
-3-element Ket:
+julia> ψ = Snowflake.fock(1, 3)
+3-element Ket{ComplexF64}:
 0.0 + 0.0im
 1.0 + 0.0im
 0.0 + 0.0im
+
+
+julia> ψ = Snowflake.fock(1, 3,ComplexF32) # specifying a type other than ComplexF64
+3-element Ket{ComplexF32}:
+0.0f0 + 0.0f0im
+1.0f0 + 0.0f0im
+0.0f0 + 0.0f0im
 ```
 """
 function fock(i, hspace_size,T::Type{<:Complex}=ComplexF64)

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -12,14 +12,20 @@ julia> ψ = Snowflake.Ket([1.0; 0.0; 0.0])
 1.0 + 0.0im
 0.0 + 0.0im
 0.0 + 0.0im
+
+
 ```
 A better way to initialize a Ket is to use a pre-built basis such as the `fock` basis. See [`fock`](@ref) for further information on this function. 
 ```jldoctest
-julia> ψ = Snowflake.fock(2, 3)
-3-element Ket{ComplexF64}:
+julia> ψ = Snowflake.fock(2, 3);
+
+julia> print(ψ)
+3-element Ket:
 0.0 + 0.0im
 0.0 + 0.0im
 1.0 + 0.0im
+
+
 ```
 """
 struct Ket{T<:Complex}
@@ -48,18 +54,17 @@ A structure representing a Bra (i.e. a row vector of complex values). A Bra is c
 - `data` -- the stored values.
 # Examples
 ```jldoctest
-julia> ψ = Snowflake.fock(1, 3)
-3-element Ket{ComplexF64}:
+julia> ψ = Snowflake.fock(1, 3);
+
+julia> print(ψ)
+3-element Ket:
 0.0 + 0.0im
 1.0 + 0.0im
 0.0 + 0.0im
 
 
-julia> _ψ = Snowflake.Bra(ψ)
-3-element Bra{ComplexF64}:
-0.0 - 0.0im
-1.0 - 0.0im
-0.0 - 0.0im
+julia> print(_ψ)
+Bra(Any[0.0 - 0.0im 1.0 - 0.0im 0.0 - 0.0im])
 
 
 julia> _ψ * ψ    # A Bra times a Ket is a scalar
@@ -247,8 +252,10 @@ Compute the expectation value ⟨`ψ`|`A`|`ψ`⟩ given Operator `A` and Ket |`�
 
 # Examples
 ```jldoctest
-julia> ψ = Ket([0.0; 1.0])
-2-element Ket{ComplexF64}:
+julia> ψ = Ket([0.0; 1.0]);
+
+julia> print(ψ)
+2-element Ket:
 0.0 + 0.0im
 1.0 + 0.0im
 
@@ -282,20 +289,26 @@ More details about the Kronecker product can be found
 
 # Examples
 ```jldoctest
-julia> ψ_0 = Ket([0.0; 1.0])
-2-element Ket{ComplexF64}:
+julia> ψ_0 = Ket([0.0; 1.0]);
+
+julia> print(ψ_0)
+2-element Ket:
 0.0 + 0.0im
 1.0 + 0.0im
 
 
-julia> ψ_1 = Ket([1.0; 0.0])
-2-element Ket{ComplexF64}:
+julia> ψ_1 = Ket([1.0; 0.0]);
+
+julia> print(ψ_1)
+2-element Ket:
 1.0 + 0.0im
 0.0 + 0.0im
 
 
-julia> ψ_0_1 = kron(ψ_0, ψ_1)
-4-element Ket{ComplexF64}:
+julia> ψ_0_1 = kron(ψ_0, ψ_1);
+
+julia> print(ψ_0_1)
+4-element Ket:
 0.0 + 0.0im
 0.0 + 0.0im
 1.0 + 0.0im
@@ -544,27 +557,22 @@ end
 Returns the `i`th fock basis of a Hilbert space with size `hspace_size` as Snowflake.Ket, of default type ComplexF64.
 # Examples
 ```jldoctest
-julia> ψ = Snowflake.fock(0, 3)
-3-element Ket{ComplexF64}:
+julia> ψ = Snowflake.fock(0, 3);
+
+julia> print(ψ)
+3-element Ket:
 1.0 + 0.0im
 0.0 + 0.0im
 0.0 + 0.0im
 
 
-julia> ψ = Snowflake.fock(1, 3)
-3-element Ket{ComplexF64}:
+julia> ψ = Snowflake.fock(1, 3);
+
+julia> print(ψ)
+3-element Ket:
 0.0 + 0.0im
 1.0 + 0.0im
 0.0 + 0.0im
-
-
-julia> ψ = Snowflake.fock(1, 3,ComplexF32) # specifying a type other than ComplexF64
-3-element Ket{ComplexF32}:
-0.0f0 + 0.0f0im
-1.0f0 + 0.0f0im
-0.0f0 + 0.0f0im
-
-
 ```
 """
 function fock(i, hspace_size,T::Type{<:Complex}=ComplexF64)

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -177,7 +177,9 @@ Base.:*(A::Operator, B::Operator) = Operator(A.data * B.data)
 Base.:*(s::Any, A::Operator) = Operator(s*A.data)
 Base.:+(A::Operator, B::Operator) = Operator(A.data+ B.data)
 Base.:-(A::Operator, B::Operator) = Operator(A.data- B.data)
-Base.length(x::Union{Ket, Bra}) = Base.length(x.data)
+Base.length(x::Union{Ket, Bra}) = length(x.data)
+
+Base.exp(A::Operator) = Operator(exp(A.data))
 
 """
     Base.getindex(A::Operator, m::Int64, n::Int64)

--- a/src/core/quantum_gate.jl
+++ b/src/core/quantum_gate.jl
@@ -119,14 +119,13 @@ Update the `state` by applying a `gate` to it.
 
 # Examples
 ```jldoctest
-julia> ψ_0 = fock(0, 2);
-
-julia> print(ψ_0)
+julia> ψ_0 = fock(0, 2)
 2-element Ket{ComplexF64}:
 1.0 + 0.0im
 0.0 + 0.0im
 
-julia> apply_gate!(ψ_0, sigma_x(1));
+
+julia> apply_gate!(ψ_0, sigma_x(1))
 
 julia> print(ψ_0)
 2-element Ket{ComplexF64}:
@@ -982,19 +981,17 @@ Return a `Ket` which results from applying `Gate` `M` to `Ket` `x`.
 
 # Examples
 ```jldoctest
-julia> ψ_0 = fock(0, 2);
-
-julia> print(ψ_0)
+julia> ψ_0 = fock(0, 2)
 2-element Ket{ComplexF64}:
 1.0 + 0.0im
 0.0 + 0.0im
 
-julia> ψ_1 = sigma_x(1)*ψ_0;
 
-julia> print(ψ_1)
+julia> ψ_1 = sigma_x(1)*ψ_0
 2-element Ket{ComplexF64}:
 0.0 + 0.0im
 1.0 + 0.0im
+
 
 ```
 """

--- a/src/core/visualize.jl
+++ b/src/core/visualize.jl
@@ -34,6 +34,7 @@ julia> ket = Ket(1/sqrt(2)*[1, 1])
 0.7071067811865475 + 0.0im
 0.7071067811865475 + 0.0im
 
+
 julia> bloch_sphere = BlochSphere(vector_color="green");
 
 ```
@@ -140,6 +141,7 @@ julia> ket = Ket(1/sqrt(2)*[1, 1])
 2-element Ket{ComplexF64}:
 0.7071067811865475 + 0.0im
 0.7071067811865475 + 0.0im
+
 
 
 ```

--- a/test/qobj.jl
+++ b/test/qobj.jl
@@ -45,6 +45,12 @@ using Test
 
 end
 
+@testset "operator_exp" begin
+    theta = pi/8
+    exponential = exp(-im*theta/2*sigma_x())
+    @test exponential ≈ rotation_x(theta)
+end
+
 @testset "pauli_operators" begin
     x = sigma_x()
     z = sigma_z()


### PR DESCRIPTION
Adds a function which computes the matrix exponential of an operator. A bug with the Base.show(io::IO, x::Ket) function was also fixed. This lead to issues with some of the doctests.

Fixes #45