### PR TITLE
Fix/add strict doctests

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,7 +15,8 @@ makedocs(
         #"Simulating Quantum Systems" => "simulating_quantum_systems.md",            
         "Library" => "library.md",
     ],
-    doctestfilters = [uuid_regex]
+    doctestfilters = [uuid_regex],
+    strict = true
 )
 
 # Documenter can also automatically deploy documentation to gh-pages.

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -114,7 +114,7 @@ style="height:825px;width:100%;">
 </iframe>
 ```
 ```@docs
-plot_bloch_sphere_animation(density_matrix_list::Vector{Operator};
+plot_bloch_sphere_animation(density_matrix_list::Vector{Operator{T}} where {T<:Complex};
     qubit_id::Int = 1,
     animated_bloch_sphere::AnimatedBlochSphere = AnimatedBlochSphere())
 ```

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -6,7 +6,7 @@ A Ket represents a *quantum wavefunction* and is mathematically equivalent to a 
 Although NOT the preferred way, one can directly build a Ket object by passing a column vector as the initializer. 
 ```jldoctest
 julia> using Snowflake
-# THIS SHOULD CAUSE THE DOCUMENTATION CI/CD TO FAIL
+
 julia> ψ = Snowflake.Ket([1.0; 0.0; 0.0])
 3-element Ket{ComplexF64}:
 1.0 + 0.0im

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -73,7 +73,6 @@ Underlying data Matrix{ComplexF64}:
 0.0 + 0.0im    0.0 + 0.0im    0.0 + 0.0im
 ```
 """
-
 struct Bra{T<:Complex}
     data::LinearAlgebra.Adjoint{T,Vector{T}}
     # constructor overload from Ket{Complex{T}}
@@ -83,9 +82,9 @@ struct Bra{T<:Complex}
 end
 
 function Base.show(io::IO, x::Bra)
-    println("$(length(x.data))-element Bra{$(eltype(x.data))}:")
+    println(io, "$(length(x.data))-element Bra{$(eltype(x.data))}:")
     for val in x.data
-        println(val)
+        println(io, val)
     end
 end
 

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -7,9 +7,7 @@ Although NOT the preferred way, one can directly build a Ket object by passing a
 ```jldoctest
 julia> using Snowflake
 
-julia> ψ = Snowflake.Ket([1.0; 0.0; 0.0]);
-
-julia> print(ψ)
+julia> ψ = Snowflake.Ket([1.0; 0.0; 0.0])
 3-element Ket{ComplexF64}:
 1.0 + 0.0im
 0.0 + 0.0im
@@ -17,9 +15,7 @@ julia> print(ψ)
 ```
 A better way to initialize a Ket is to use a pre-built basis such as the `fock` basis. See [`fock`](@ref) for further information on this function. 
 ```jldoctest
-julia> ψ = Snowflake.fock(2, 3);
-
-julia> print(ψ)
+julia> ψ = Snowflake.fock(2, 3)
 3-element Ket{ComplexF64}:
 0.0 + 0.0im
 0.0 + 0.0im
@@ -38,9 +34,9 @@ Ket(x::Vector{T}) where {T<:Real} = Ket{Complex{T}}(convert(Array{Complex{T},1},
 Ket(x::Vector{T},S::Type{<:Complex}=ComplexF64) where {T<:Integer}=Ket(Vector{S}(x))
 
 function Base.show(io::IO, x::Ket)
-    println("$(length(x.data))-element Ket{$(eltype(x.data))}:")
+    println(io, "$(length(x.data))-element Ket{$(eltype(x.data))}:")
     for val in x.data
-        println(val)
+        println(io, val)
     end
 end
 
@@ -52,17 +48,14 @@ A structure representing a Bra (i.e. a row vector of complex values). A Bra is c
 - `data` -- the stored values.
 # Examples
 ```jldoctest
-julia> ψ = Snowflake.fock(1, 3);
-
-julia> print(ψ)
+julia> ψ = Snowflake.fock(1, 3)
 3-element Ket{ComplexF64}:
 0.0 + 0.0im
 1.0 + 0.0im
 0.0 + 0.0im
 
-julia> _ψ = Snowflake.Bra(ψ);
 
-julia> print(_ψ)
+julia> _ψ = Snowflake.Bra(ψ)
 3-element Bra{ComplexF64}:
 0.0 - 0.0im
 1.0 - 0.0im
@@ -235,12 +228,13 @@ Compute the trace of Operator `A`.
 julia> I = eye()
 (2, 2)-element Snowflake.Operator:
 Underlying data Matrix{ComplexF64}:
-1.0 + 0.0im    0 + 0im
-0 + 0im    1.0 + 0.0im
+1.0 + 0.0im    0.0 + 0.0im
+0.0 + 0.0im    1.0 + 0.0im
 
 
 julia> trace = tr(I)
 2.0 + 0.0im
+
 ```
 """
 tr(A::Operator)=LinearAlgebra.tr(A.data)
@@ -252,9 +246,7 @@ Compute the expectation value ⟨`ψ`|`A`|`ψ`⟩ given Operator `A` and Ket |`�
 
 # Examples
 ```jldoctest
-julia> ψ = Ket([0.0; 1.0]);
-
-julia> print(ψ)
+julia> ψ = Ket([0.0; 1.0])
 2-element Ket{ComplexF64}:
 0.0 + 0.0im
 1.0 + 0.0im
@@ -289,25 +281,19 @@ More details about the Kronecker product can be found
 
 # Examples
 ```jldoctest
-julia> ψ_0 = Ket([0.0; 1.0]);
-
-julia> print(ψ_0)
+julia> ψ_0 = Ket([0.0; 1.0])
 2-element Ket{ComplexF64}:
 0.0 + 0.0im
 1.0 + 0.0im
 
 
-julia> ψ_1 = Ket([1.0; 0.0]);
-
-julia> print(ψ_1)
+julia> ψ_1 = Ket([1.0; 0.0])
 2-element Ket{ComplexF64}:
 1.0 + 0.0im
 0.0 + 0.0im
 
 
-julia> ψ_0_1 = kron(ψ_0, ψ_1);
-
-julia> print(ψ_0_1)
+julia> ψ_0_1 = kron(ψ_0, ψ_1)
 4-element Ket{ComplexF64}:
 0.0 + 0.0im
 0.0 + 0.0im
@@ -461,14 +447,13 @@ end
 Returns the number of qubits associated with a `Ket` or a `Bra`.
 # Examples
 ```jldoctest
-julia> ψ = Ket([1., 0., 0., 0.]);
-
-julia> print(ψ)
+julia> ψ = Ket([1., 0., 0., 0.])
 4-element Ket{ComplexF64}:
 1.0 + 0.0im
 0.0 + 0.0im
 0.0 + 0.0im
 0.0 + 0.0im
+
 
 julia> get_num_qubits(ψ)
 2
@@ -525,9 +510,7 @@ Returns the number of bodies associated with a `Ket` or a `Bra` given the
 `hilbert_space_size_per_body`.
 # Examples
 ```jldoctest
-julia> ψ = Ket([1., 0., 0., 0., 0., 0., 0., 0., 0.]);
-
-julia> print(ψ)
+julia> ψ = Ket([1., 0., 0., 0., 0., 0., 0., 0., 0.])
 9-element Ket{ComplexF64}:
 1.0 + 0.0im
 0.0 + 0.0im
@@ -538,6 +521,7 @@ julia> print(ψ)
 0.0 + 0.0im
 0.0 + 0.0im
 0.0 + 0.0im
+
 
 julia> get_num_bodies(ψ, 3)
 2
@@ -559,31 +543,26 @@ end
 Returns the `i`th fock basis of a Hilbert space with size `hspace_size` as Snowflake.Ket, of default type ComplexF64.
 # Examples
 ```jldoctest
-julia> ψ = Snowflake.fock(0, 3);
-
-julia> print(ψ)
+julia> ψ = Snowflake.fock(0, 3)
 3-element Ket{ComplexF64}:
 1.0 + 0.0im
 0.0 + 0.0im
 0.0 + 0.0im
 
 
-julia> ψ = Snowflake.fock(1, 3);
-
-julia> print(ψ)
+julia> ψ = Snowflake.fock(1, 3)
 3-element Ket{ComplexF64}:
 0.0 + 0.0im
 1.0 + 0.0im
 0.0 + 0.0im
 
-# specifying a type other than ComplexF64:
-julia> ψ = Snowflake.fock(1, 3,ComplexF32);
 
-julia> print(ψ)
+julia> ψ = Snowflake.fock(1, 3,ComplexF32) # specifying a type other than ComplexF64
 3-element Ket{ComplexF32}:
-0.0 + 0.0im
-1.0 + 0.0im
-0.0 + 0.0im
+0.0f0 + 0.0f0im
+1.0f0 + 0.0f0im
+0.0f0 + 0.0f0im
+
 
 ```
 """
@@ -643,9 +622,7 @@ Returns a coherent state for the parameter `alpha` in a Fock space of size `hspa
 
     # Examples
 ```jldoctest
-julia> ψ = Snowflake.coherent(2.0,20);
-
-julia> print(ψ)
+julia> ψ = Snowflake.coherent(2.0,20)
 20-element Ket{ComplexF64}:
 0.1353352832366127 + 0.0im
 0.2706705664732254 + 0.0im

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -6,7 +6,7 @@ A Ket represents a *quantum wavefunction* and is mathematically equivalent to a 
 Although NOT the preferred way, one can directly build a Ket object by passing a column vector as the initializer. 
 ```jldoctest
 julia> using Snowflake
-
+# THIS SHOULD CAUSE THE DOCUMENTATION CI/CD TO FAIL
 julia> ψ = Snowflake.Ket([1.0; 0.0; 0.0])
 3-element Ket{ComplexF64}:
 1.0 + 0.0im

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -308,10 +308,8 @@ q[2]:───────X──
                
 
 
-julia> ket = simulate(c);
-
-julia> print(ket)
-4-element Ket:
+julia> ket = simulate(c)
+4-element Ket{ComplexF64}:
 0.7071067811865475 + 0.0im
 0.0 + 0.0im
 0.0 + 0.0im

--- a/src/core/quantum_gate.jl
+++ b/src/core/quantum_gate.jl
@@ -544,7 +544,7 @@ julia> x = sigma_x(1);
 
 julia> get_operator(x)
 (2, 2)-element Snowflake.Operator:
-Underlying data Matrix{Complex}:
+Underlying data Matrix{ComplexF64}:
 0.0 + 0.0im    1.0 + 0.0im
 1.0 + 0.0im    0.0 + 0.0im
 

--- a/src/core/visualize.jl
+++ b/src/core/visualize.jl
@@ -29,10 +29,8 @@ Contains fields which affect how a Bloch sphere is generated.
     
 # Examples
 ```jldoctest
-julia> ket = Ket(1/sqrt(2)*[1, 1]);
-
-julia> print(ket)
-2-element Ket:
+julia> ket = Ket(1/sqrt(2)*[1, 1])
+2-element Ket{ComplexF64}:
 0.7071067811865475 + 0.0im
 0.7071067811865475 + 0.0im
 
@@ -138,12 +136,11 @@ be modified by passing a [`BlochSphere`](@ref) struct.
     
 # Examples
 ```jldoctest
-julia> ket = Ket(1/sqrt(2)*[1, 1]);
+julia> ket = Ket(1/sqrt(2)*[1, 1])
+2-element Ket{ComplexF64}:
+0.7071067811865475 + 0.0im
+0.7071067811865475 + 0.0im
 
-julia> print(ket)
-2-element Ket:
-0.7071067811865475 + 0.0im
-0.7071067811865475 + 0.0im
 
 ```
 ```
@@ -182,7 +179,7 @@ sphere can be modified by passing a [`BlochSphere`](@ref) struct.
 julia> ρ = Operator([1.0 0.0;
                      0.0 0.0])
 (2, 2)-element Snowflake.Operator:
-Underlying data Matrix{Complex}:
+Underlying data Matrix{ComplexF64}:
 1.0 + 0.0im    0.0 + 0.0im
 0.0 + 0.0im    0.0 + 0.0im
 


### PR DESCRIPTION
This pull request should cause the CI/CD to fail for the documentation if there is an error in the doctests. This was not the case before. All errors and warnings were also removed from the documentation. I will run a test to ensure that the CI/CD does indeed fail if there is a doctest error.

Fixes #56 