### PR TITLE
fix(ci): remove deploydocs for pull request ci

### DIFF
--- a/.github/workflows/deploy_documentation.yml
+++ b/.github/workflows/deploy_documentation.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
     tags: '*'
-  pull_request:
 
 jobs:
   build:
@@ -19,4 +18,4 @@ jobs:
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
-        run: julia --project=docs/ docs/make.jl
+        run: julia --project=docs/ docs/make_and_deploy.jl

--- a/.github/workflows/test_documentation.yml
+++ b/.github/workflows/test_documentation.yml
@@ -1,0 +1,16 @@
+name: Documentation
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: '1.6.7'
+      - name: Install dependencies
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build
+        run: julia --project=docs/ docs/make.jl

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,12 +18,3 @@ makedocs(
     doctestfilters = [uuid_regex],
     strict = true
 )
-
-# Documenter can also automatically deploy documentation to gh-pages.
-# See "Hosting Documentation" and deploydocs() in the Documenter manual
-# for more information.
-deploydocs(
-    repo = "github.com/anyonlabs/Snowflake.jl.git",
-)
-
-

--- a/docs/make_and_deploy.jl
+++ b/docs/make_and_deploy.jl
@@ -1,0 +1,8 @@
+include("make.jl")
+
+# Documenter can also automatically deploy documentation to gh-pages.
+# See "Hosting Documentation" and deploydocs() in the Documenter manual
+# for more information.
+deploydocs(
+    repo = "github.com/anyonlabs/Snowflake.jl.git",
+)


### PR DESCRIPTION
Ensures that the documentation is only deployed after a push to the main branch.

Fixes #62