### PR TITLE
fix: a bug with eye() constructor is fixed.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,10 @@
 name = "Snowflake"
 uuid = "7bd9edc1-4fdc-40a1-a0f6-da58fb4f45eb"
-authors = [
-    "Alireza Yazdi <alireza@anyonsys.com>",
-    "Paul Le Roux <pleroux@anyonsys.com>",
-    "Facundo Sosa-Rey <facundo@anyonsys.com>",
-    "Nicolas Poirier <nicolas.poirier2@mail.mcgill.ca>"
-]
+authors = ["Alireza Yazdi <alireza@anyonsys.com>", "Paul Le Roux <pleroux@anyonsys.com>", "Facundo Sosa-Rey <facundo@anyonsys.com>", "Nicolas Poirier <nicolas.poirier2@mail.mcgill.ca>"]
 version = "0.1.0"
 
 [deps]
+Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/coverage.jl
+++ b/coverage.jl
@@ -27,6 +27,5 @@ covered_lines, total_lines = get_summary(coverage)
 #clean .cov files
 clean_folder("src")
 clean_folder("test")
-clean_folder("protobuf")
 
 return covered_lines, total_lines

--- a/src/core/quantum_gate.jl
+++ b/src/core/quantum_gate.jl
@@ -507,22 +507,8 @@ I = \\begin{bmatrix}
 ```
 """
 eye(T::Type{<:Complex}=ComplexF64) = DenseOperator(Matrix{T}(1.0I, 2, 2))
+eye(size::Integer, T::Type{<:Complex}=ComplexF64) = DenseOperator(Matrix{T}(1.0I, size, size))
 
-# Contruct eye() of any size (or qubit_count)
-function eye(qubit_count::Integer,T::Type{<:Complex}=ComplexF64)
-    if qubit_count<1
-        throw(DomainError(qubit_count,
-            "Must have qubit_count>0"))
-    end 
-
-    if qubit_count==1
-        return eye(T)
-    elseif qubit_count==2
-        return kron(eye(qubit_count-1,T),eye(T))
-    else
-        return kron(eye(qubit_count-1,T),eye(qubit_count-2,T))
-    end
-end
 
 
 """

--- a/test/gate.jl
+++ b/test/gate.jl
@@ -25,10 +25,9 @@ end
 
 @testset "gate_set" begin
 
-    @test eye(2)≈kron(eye(),eye())
-    @test_throws DomainError eye(0)
-    @test eye(3)≈kron(eye(2),eye())
-    @test eye(4)≈kron(eye(3),eye(2))
+    @test eye(4)≈kron(eye(),eye())
+    @test eye(8)≈kron(eye(4),eye())
+    @test eye(6)≈kron(eye(3),eye(2))
 
     H = hadamard(1)
     h_oper=get_operator(H)

--- a/test/test_functions.jl
+++ b/test/test_functions.jl
@@ -5,7 +5,7 @@ function test_inverse(gate::AbstractGate)
     inverse_gate=inv(gate)
     target_count=length(get_connected_qubits(gate))
 
-    return( get_operator(gate)*get_operator(inverse_gate) ≈ eye(target_count) )
+    return( get_operator(gate)*get_operator(inverse_gate) ≈ eye(2^target_count) )
 end
 
 function make_array(


### PR DESCRIPTION
eye() constructor was using a faulty recursive algorithm. It is now fixed so that `eye(n)` results in an identity matrix of size `n`.