### PR TITLE
Refactor/use slurping for push

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -47,8 +47,8 @@ q[2]:
 In Snowflake, all qubits start in state $\left|0\right\rangle$. Our circuit is, therefore,  in state $\left|00\right\rangle$. We now proceed by adding gates to our circuit.
 
 ```jldoctest getting_started
-push!(c, [hadamard(1)])
-push!(c, [control_x(1, 2)])
+push!(c, hadamard(1))
+push!(c, control_x(1, 2))
 
 print(c)
 
@@ -94,8 +94,8 @@ The script below puts all the steps above together:
 ```julia
 using Snowflake, SnowflakePlots
 c = QuantumCircuit(qubit_count=2)
-push!(c, [hadamard(1)])
-push!(c, [control_x(1, 2)])
+push!(c, hadamard(1))
+push!(c, control_x(1, 2))
 ψ = simulate(c)
 plot_histogram(c, 100)
 ```

--- a/docs/src/tutorials/introductory/entanglement_demonstration.md
+++ b/docs/src/tutorials/introductory/entanglement_demonstration.md
@@ -55,7 +55,7 @@ q[2]:
 We must now apply our gates to our circuit.
 
 ```jldoctest entanglement_demonstration_tutorial; output = false
-push!(circuit, [hadamard(1), control_x(1, 2)])
+push!(circuit, hadamard(1), control_x(1, 2))
 
 # output
 

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -27,7 +27,7 @@ Base.@kwdef struct QuantumCircuit
         c=new(qubit_count,[])
 
         # add gates, with ensure_gate_is_in_circuit()
-        push!(c,gates)
+        push!(c,gates...)
 
         return c
     end
@@ -69,15 +69,10 @@ q[2]:───────X────X──
 
 ```
 """
-function Base.push!(circuit::QuantumCircuit, gate::AbstractGate)
-    ensure_gate_is_in_circuit(circuit, gate)
-    push!(get_circuit_gates(circuit), gate)
-    return circuit
-end
-
-function Base.push!(circuit::QuantumCircuit, gates::Vector{<:AbstractGate})
-    for gate in gates
-        push!(circuit, gate)
+function Base.push!(circuit::QuantumCircuit, gates::AbstractGate...)
+    for single_gate in gates
+        ensure_gate_is_in_circuit(circuit, single_gate)
+        push!(get_circuit_gates(circuit), single_gate)
     end
     return circuit
 end

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -38,16 +38,19 @@ get_num_qubits(circuit::QuantumCircuit)=circuit.qubit_count
 get_circuit_gates(circuit::QuantumCircuit)=circuit.gates
 
 """
-    push!(circuit::QuantumCircuit, gate::AbstractGate)
-    push!(circuit::QuantumCircuit, gates::Array{AbstractGate})
+    push!(circuit::QuantumCircuit, gates::AbstractGate...)
 
-Pushes a single gate or an array of gates to the `circuit` gates. This function is mutable. 
+Inserts one or more `gates` at the end of a `circuit`.
+
+A `Vector` of `AbstractGate` objects can be passed to this function by using splatting.
+More details about splatting are provided
+[here](https://docs.julialang.org/en/v1/manual/faq/#What-does-the-...-operator-do?).
 
 # Examples
 ```jldoctest
 julia> c = QuantumCircuit(qubit_count = 2);
 
-julia> push!(c, [hadamard(1),sigma_x(2)])
+julia> push!(c, hadamard(1), sigma_x(2))
 Quantum Circuit Object:
    qubit_count: 2 
 q[1]:──H───────
@@ -64,6 +67,18 @@ q[1]:──H─────────*──
                  |  
 q[2]:───────X────X──
                     
+
+
+
+julia> gate_list = [sigma_x(1), hadamard(2)];
+
+julia> push!(c, gate_list...)
+Quantum Circuit Object:
+   qubit_count: 2 
+q[1]:──H─────────*────X───────
+                 |            
+q[2]:───────X────X─────────H──
+                              
 
 
 
@@ -420,7 +435,7 @@ Removes the last gate from `circuit.gates`.
 ```jldoctest
 julia> c = QuantumCircuit(qubit_count = 2);
 
-julia> push!(c, [hadamard(1),sigma_x(2)])
+julia> push!(c, hadamard(1), sigma_x(2))
 Quantum Circuit Object:
    qubit_count: 2 
 q[1]:──H───────
@@ -751,7 +766,7 @@ is 50% and the probability of measuring 11 is also 50%.
 ```jldoctest get_circuit_measurement_probabilities
 julia> circuit = QuantumCircuit(qubit_count=2);
 
-julia> push!(circuit, [hadamard(1), sigma_x(2)])
+julia> push!(circuit, hadamard(1), sigma_x(2))
 Quantum Circuit Object:
    qubit_count: 2 
 q[1]:──H───────
@@ -847,7 +862,7 @@ The dictionary keys are the instruction_symbol of the gates while the values are
 ```jldoctest
 julia> c = QuantumCircuit(qubit_count=2);
 
-julia> push!(c, [hadamard(1), hadamard(2)]);
+julia> push!(c, hadamard(1), hadamard(2));
 
 julia> push!(c, control_x(1, 2));
 
@@ -890,7 +905,7 @@ Returns the number of gates in the `circuit`.
 ```jldoctest
 julia> c = QuantumCircuit(qubit_count=2);
 
-julia> push!(c, [hadamard(1), hadamard(2)]);
+julia> push!(c, hadamard(1), hadamard(2));
 
 julia> push!(c, control_x(1, 2))
 Quantum Circuit Object:

--- a/src/core/transpile.jl
+++ b/src/core/transpile.jl
@@ -427,7 +427,7 @@ function transpile(::CastSwapToCZGateTranspiler, circuit::QuantumCircuit)::Quant
 
     for gate in get_circuit_gates(circuit)
         if is_gate_type(gate, Snowflake.Swap)
-            push!(output, cast_to_cz(gate))
+            push!(output, cast_to_cz(gate)...)
         else
             push!(output, gate)
         end
@@ -484,7 +484,7 @@ function transpile(::CastCXToCZGateTranspiler, circuit::QuantumCircuit)::Quantum
 
     for gate in get_circuit_gates(circuit)
         if is_gate_type(gate, Snowflake.ControlX)
-            push!(output, cast_to_cz(gate))
+            push!(output, cast_to_cz(gate)...)
         else
             push!(output, gate)
         end
@@ -548,7 +548,7 @@ function transpile(::CastISwapToCZGateTranspiler, circuit::QuantumCircuit)::Quan
 
     for gate in get_circuit_gates(circuit)
         if is_gate_type(gate, Snowflake.ISwap)
-            push!(output, cast_to_cz(gate))
+            push!(output, cast_to_cz(gate)...)
         else
             push!(output, gate)
         end
@@ -629,7 +629,7 @@ function transpile(::CastToffoliToCXGateTranspiler, circuit::QuantumCircuit)::Qu
 
     for gate in get_circuit_gates(circuit)
         if is_gate_type(gate, Snowflake.Toffoli)
-            push!(output, cast_to_cx(gate))
+            push!(output, cast_to_cx(gate)...)
         else
             push!(output, gate)
         end
@@ -839,7 +839,7 @@ function transpile(transpiler_stage::CastToPhaseShiftAndHalfRotationXTranspiler,
             end
 
             gate_array=cast_to_phase_shift_and_half_rotation_x(gate;atol=atol)
-            push!(output_circuit,gate_array)
+            push!(output_circuit, gate_array...)
         end
     end
 
@@ -943,7 +943,7 @@ function transpile(::CastUniversalToRzRxRzTranspiler, circuit::QuantumCircuit)::
             end
 
             gate_array=cast_to_rz_rx_rz(gate)
-            push!(output_circuit,gate_array)
+            push!(output_circuit, gate_array...)
         end
     end
 
@@ -1016,7 +1016,7 @@ function transpile(::CastRxToRzAndHalfRotationXTranspiler, circuit::QuantumCircu
         
         if is_gate_type(gate, RotationX)
             gate_array=cast_rx_to_rz_and_half_rotation_x(gate)
-            push!(output_circuit,gate_array)
+            push!(output_circuit, gate_array...)
         else
             push!(output_circuit,gate)
         end
@@ -1261,7 +1261,7 @@ function transpile(::SwapQubitsForLineConnectivityTranspiler, circuit::QuantumCi
                 consecutive_mapping
             )
 
-            push!(output_circuit,gates_block)
+            push!(output_circuit, gates_block...)
         else
             # no effect for single-target gate
             push!(output_circuit,gate)
@@ -1556,7 +1556,7 @@ function transpile(::RemoveSwapBySwappingGates, circuit::QuantumCircuit)::Quantu
             push!(reverse_transpiled_gates, moved_gate)
         end
     end
-    push!(output_circuit, reverse(reverse_transpiled_gates))
+    push!(output_circuit, reverse(reverse_transpiled_gates)...)
     return output_circuit
 end
 

--- a/test/circuit.jl
+++ b/test/circuit.jl
@@ -18,10 +18,10 @@ end
 @testset "push_pop_gate" begin
     c = QuantumCircuit(qubit_count = 2)
     print(c)
-    push!(c, [hadamard(1)])
+    push!(c, hadamard(1))
     @test length(get_circuit_gates(c)) == 1
 
-    push!(c, [control_x(1, 2)])
+    push!(c, control_x(1, 2))
     @test length(get_circuit_gates(c)) == 2
     pop!(c)
     @test length(get_circuit_gates(c)) == 1
@@ -37,24 +37,24 @@ end
 @testset "print_circuit" begin
     c = QuantumCircuit(qubit_count = 2)
     for i = 1:50
-        push!(c, [control_x(1, 2)])
+        push!(c, control_x(1, 2))
     end
     print(c)
 
     c = QuantumCircuit(qubit_count = 10)
-    push!(c, [control_x(9, 10)])
+    push!(c, control_x(9, 10))
     print(c)
 
     c = QuantumCircuit(qubit_count = 3)
-    push!(c, [control_x(1, 3),rotation(2,π,-π/4),control_z(2,1)])
+    push!(c, control_x(1, 3), rotation(2,π,-π/4), control_z(2,1))
     print(c)
 end
 
 
 @testset "gate type in circuit" begin
     circuit = QuantumCircuit(qubit_count = 2)
-    push!(circuit, [hadamard(1)])
-    push!(circuit, [control_x(1, 2)])   
+    push!(circuit, hadamard(1))
+    push!(circuit, control_x(1, 2))   
 
     @test circuit_contains_gate_type(circuit, Snowflake.Hadamard)
     @test circuit_contains_gate_type(circuit, Snowflake.ControlX)
@@ -72,8 +72,8 @@ end
     Ψ_p = (1.0 / sqrt(2.0)) * (Ψ_up + Ψ_down)
     Ψ_m = (1.0 / sqrt(2.0)) * (Ψ_up - Ψ_down)
     c = QuantumCircuit(qubit_count = 2)
-    push!(c, [hadamard(1)])
-    push!(c, [control_x(1, 2)])
+    push!(c, hadamard(1))
+    push!(c, control_x(1, 2))
     ψ = simulate(c)
     @test ψ ≈ 1 / sqrt(2.0) * (kron(Ψ_up, Ψ_up) + kron(Ψ_down, Ψ_down))
 
@@ -96,9 +96,9 @@ end
 
     c = QuantumCircuit(qubit_count = 2)
 
-    push!(c, [hadamard(1), sigma_x(2)])
-    push!(c, [hadamard(2)])
-    push!(c, [control_x(1, 2)])
+    push!(c, hadamard(1), sigma_x(2))
+    push!(c, hadamard(2))
+    push!(c, control_x(1, 2))
     ψ = simulate(c)
 
     @test ψ ≈ kron(Ψ_m, Ψ_m)
@@ -128,7 +128,7 @@ end
 
 @testset "get_num_gates_per_type" begin
     c = QuantumCircuit(qubit_count = 2)
-    push!(c, [sigma_x(1), sigma_x(2)])
+    push!(c, sigma_x(1), sigma_x(2))
     push!(c, control_x(1, 2))
     push!(c, sigma_x(2))
     gate_counts = get_num_gates_per_type(c)
@@ -137,7 +137,7 @@ end
 
 @testset "get_num_gates" begin
     c = QuantumCircuit(qubit_count = 2)
-    push!(c, [sigma_x(1), sigma_x(2)])
+    push!(c, sigma_x(1), sigma_x(2))
     push!(c, control_x(1, 2))
     push!(c, sigma_x(2))
     num_gates = get_num_gates(c)
@@ -146,7 +146,7 @@ end
 
 @testset "get_measurement_probabilities" begin
     circuit = QuantumCircuit(qubit_count=2)
-    push!(circuit, [hadamard(1), sigma_x(2)])
+    push!(circuit, hadamard(1), sigma_x(2))
     probabilities = get_measurement_probabilities(circuit)
     @test probabilities ≈ [0, 0.5, 0, 0.5]
 

--- a/test/submit_circuit.jl
+++ b/test/submit_circuit.jl
@@ -3,8 +3,8 @@ using Test
 
 @testset "submit_job_iswap" begin
     c = QuantumCircuit(qubit_count = 2)
-    push!(c, [sigma_x(1)])
-    push!(c, [iswap(1, 2)])
+    push!(c, sigma_x(1))
+    push!(c, iswap(1, 2))
 
     try
         owner = ENV["SNOWFLAKE_ID"]


### PR DESCRIPTION
Enables slurping for pushing `AbstractGate` objects to a `QuantumCircuit`. The function `push!(circuit::QuantumCircuit, gates::AbstractGate...)` now better matches `Base.push!`.

More details about slurping are provided here: https://docs.julialang.org/en/v1/manual/faq/#What-does-the-...-operator-do?

Fixes #200