### PR TITLE
Fix MovedGate functions if moved more than once

### DIFF
--- a/src/core/quantum_gate.jl
+++ b/src/core/quantum_gate.jl
@@ -212,9 +212,11 @@ Base.inv(gate::MovedControlledGate) = MovedControlledGate(inv(gate.original_gate
 
 get_gate_parameters(gate::UnionMovedGates) = get_gate_parameters(gate.original_gate)
 
-is_gate_type(gate::UnionMovedGates, type::Type)::Bool = isa(gate.original_gate, type)
+function is_gate_type(gate::UnionMovedGates, type::Type)::Bool
+    return is_gate_type(gate.original_gate, type)
+end
 
-get_gate_type(gate::UnionMovedGates)::Type = typeof(gate.original_gate)
+get_gate_type(gate::UnionMovedGates)::Type = get_gate_type(gate.original_gate)
 
 get_connected_qubits(gate::UnionMovedGates) = gate.connected_qubits
 

--- a/test/gate.jl
+++ b/test/gate.jl
@@ -426,6 +426,12 @@ end
     @test get_connected_qubits(moved_rx_gate) == [3]
     @test get_gate_parameters(moved_rx_gate) == Dict("theta"=>theta)
 
+    moved_twice_rx = move_gate(moved_rx_gate, qubit_mapping)
+    @test is_gate_type(moved_twice_rx, Snowflake.RotationX)
+    @test get_gate_type(moved_twice_rx) == Snowflake.RotationX
+    @test get_connected_qubits(moved_twice_rx) == [2]
+    @test get_gate_parameters(moved_twice_rx) == Dict("theta"=>theta)
+    
     inverse_moved_gate = inv(moved_rx_gate)
     @test is_gate_type(inverse_moved_gate, Snowflake.RotationX)
     @test get_connected_qubits(inverse_moved_gate) == [3]


### PR DESCRIPTION
Corrects the `get_gate_type` and `is_gate_type` functions for gates that have been moved multiple times.

Fixes #218