### PR TITLE
Feat/add permute qubits

### DIFF
--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -22,6 +22,8 @@ serialize_job
 transpile
 compare_circuits
 circuit_contains_gate_type
+permute_qubits!
+permute_qubits
 ```
 
 ## Quantum Gates

--- a/src/Snowflake.jl
+++ b/src/Snowflake.jl
@@ -91,6 +91,7 @@ export
     circuit_contains_gate_type,
     compare_kets,
     permute_qubits!,
+    permute_qubits,
    
     transpile,
     get_status_type,

--- a/src/Snowflake.jl
+++ b/src/Snowflake.jl
@@ -90,6 +90,7 @@ export
     compare_circuits,
     circuit_contains_gate_type,
     compare_kets,
+    permute_qubits!,
    
     transpile,
     get_status_type,

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -935,6 +935,48 @@ julia> get_num_gates(c)
 """
 get_num_gates(circuit::QuantumCircuit)::Integer=length(get_circuit_gates(circuit))
 
+"""
+    permute_qubits!(circuit::QuantumCircuit,
+        qubit_mapping::AbstractDict{T,T}) where T<:Integer
+
+Modifies a `circuit` by moving the gates to other qubits based on a `qubit_mapping`.
+
+The dictionary `qubit_mapping` contains key-value pairs describing how to update the target
+qubits. The key indicates which target qubit to change while the associated value specifies
+the new qubit. All the keys in the dictionary must also be present as values and vice versa.
+
+For instance, `Dict(1=>2)` is not a valid `qubit_mapping`, but `Dict(1=>2, 2=>1)` is valid.
+
+# Examples
+```jldoctest
+julia> c = QuantumCircuit(qubit_count=3);
+
+julia> push!(c, sigma_x(1), hadamard(2), sigma_y(3))
+Quantum Circuit Object:
+   qubit_count: 3 
+q[1]:──X────────────
+                    
+q[2]:───────H───────
+                    
+q[3]:────────────Y──                    
+
+
+
+julia> permute_qubits!(c, Dict(1=>3, 3=>1))
+
+julia> show(c)
+Quantum Circuit Object:
+   qubit_count: 3 
+q[1]:────────────Y──
+                    
+q[2]:───────H───────
+                    
+q[3]:──X────────────
+                    
+
+
+```
+"""
 function permute_qubits!(circuit::QuantumCircuit,
     qubit_mapping::AbstractDict{T,T}) where T<:Integer
 
@@ -966,8 +1008,51 @@ function unsafe_permute_qubits!(circuit::QuantumCircuit,
     end
 end
 
+"""
+    permute_qubits(circuit::QuantumCircuit,
+        qubit_mapping::AbstractDict{T,T})::QuantumCircuit where T<:Integer
+
+Returns a `QuantumCircuit` that is a copy of `circuit` but where the gates have been moved
+to other qubits based on a `qubit_mapping`.
+
+The dictionary `qubit_mapping` contains key-value pairs describing how to update the target
+qubits. The key indicates which target qubit to change while the associated value specifies
+the new qubit. All the keys in the dictionary must also be present as values and vice versa.
+
+For instance, `Dict(1=>2)` is not a valid `qubit_mapping`, but `Dict(1=>2, 2=>1)` is valid.
+
+# Examples
+```jldoctest
+julia> c = QuantumCircuit(qubit_count=3);
+
+julia> push!(c, sigma_x(1), hadamard(2), sigma_y(3))
+Quantum Circuit Object:
+   qubit_count: 3 
+q[1]:──X────────────
+                    
+q[2]:───────H───────
+                    
+q[3]:────────────Y──
+                    
+
+
+
+julia> permute_qubits(c, Dict(1=>3, 3=>1))
+Quantum Circuit Object:
+   qubit_count: 3 
+q[1]:────────────Y──
+                    
+q[2]:───────H───────
+                    
+q[3]:──X────────────
+                    
+
+
+
+```
+"""
 function permute_qubits(circuit::QuantumCircuit,
-    qubit_mapping::AbstractDict{T,T}) where T<:Integer
+    qubit_mapping::AbstractDict{T,T})::QuantumCircuit where T<:Integer
 
     circuit_copy = deepcopy(circuit)
     permute_qubits!(circuit_copy, qubit_mapping)

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -934,3 +934,13 @@ julia> get_num_gates(c)
 ```
 """
 get_num_gates(circuit::QuantumCircuit)::Integer=length(get_circuit_gates(circuit))
+
+function permute_qubits!(circuit::QuantumCircuit,
+    qubit_mapping::AbstractDict{T,T}) where T<:Integer
+
+    gates_list = get_circuit_gates(circuit)
+    for (i_gate, gate) in enumerate(gates_list)
+        moved_gate = move_gate(gate, qubit_mapping)
+        circuit.gates[i_gate] = moved_gate
+    end
+end

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -938,6 +938,27 @@ get_num_gates(circuit::QuantumCircuit)::Integer=length(get_circuit_gates(circuit
 function permute_qubits!(circuit::QuantumCircuit,
     qubit_mapping::AbstractDict{T,T}) where T<:Integer
 
+    assert_qubit_mapping_is_valid(qubit_mapping, get_num_qubits(circuit))
+    unsafe_permute_qubits!(circuit, qubit_mapping)
+end
+
+function assert_qubit_mapping_is_valid(qubit_mapping::AbstractDict{T,T},
+    qubit_count::Integer) where T<:Integer
+
+    sorted_keys = sort(collect(keys(qubit_mapping)))
+    sorted_values = sort(collect(values(qubit_mapping)))
+    if sorted_keys != sorted_values
+        throw(ErrorException("the qubit mapping is invalid"))
+    end
+    if last(sorted_keys) < 1 || first(sorted_keys) > qubit_count
+        throw(ErrorException("the qubit mapping has a value that does not fit in the "*
+            "circuit"))
+    end
+end
+
+function unsafe_permute_qubits!(circuit::QuantumCircuit,
+    qubit_mapping::AbstractDict{T,T}) where T<:Integer
+
     gates_list = get_circuit_gates(circuit)
     for (i_gate, gate) in enumerate(gates_list)
         moved_gate = move_gate(gate, qubit_mapping)

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -965,3 +965,11 @@ function unsafe_permute_qubits!(circuit::QuantumCircuit,
         circuit.gates[i_gate] = moved_gate
     end
 end
+
+function permute_qubits(circuit::QuantumCircuit,
+    qubit_mapping::AbstractDict{T,T}) where T<:Integer
+
+    circuit_copy = deepcopy(circuit)
+    permute_qubits!(circuit_copy, qubit_mapping)
+    return circuit_copy
+end

--- a/test/circuit.jl
+++ b/test/circuit.jl
@@ -186,3 +186,13 @@ end
         gates=[sigma_x(1), hadamard(1), sigma_x(2)])
     @test compare_circuits(circuit, expected_circuit)
 end
+
+@testset "permute_qubits!" begin
+    circuit = QuantumCircuit(qubit_count=5, gates=[sigma_x(2), sigma_y(3), sigma_z(1),
+        hadamard(4)])
+    map = Dict(1=>3, 3=>1, 2=>5, 5=>2)
+    permute_qubits!(circuit, map)
+    expected_circuit = QuantumCircuit(qubit_count=5, gates=[sigma_x(5), sigma_y(1),
+        sigma_z(3), hadamard(4)])
+    @test compare_circuits(circuit, expected_circuit)
+end

--- a/test/circuit.jl
+++ b/test/circuit.jl
@@ -195,4 +195,24 @@ end
     expected_circuit = QuantumCircuit(qubit_count=5, gates=[sigma_x(5), sigma_y(1),
         sigma_z(3), hadamard(4)])
     @test compare_circuits(circuit, expected_circuit)
+
+    circuit = QuantumCircuit(qubit_count=1, gates=[sigma_x(1)])
+    map = Dict(1=>2)
+    @test_throws ErrorException permute_qubits!(circuit, map)
+
+    circuit = QuantumCircuit(qubit_count=1, gates=[sigma_x(1)])
+    map = Dict(2=>1)
+    @test_throws ErrorException permute_qubits!(circuit, map)
+
+    circuit = QuantumCircuit(qubit_count=1, gates=[sigma_x(1)])
+    map = Dict(0=>2)
+    @test_throws ErrorException permute_qubits!(circuit, map)
+
+    circuit = QuantumCircuit(qubit_count=2, gates=[sigma_x(1), sigma_y(2)])
+    map = Dict(1=>1, 2=>1)
+    @test_throws ErrorException permute_qubits!(circuit, map)
+
+    circuit = QuantumCircuit(qubit_count=2, gates=[sigma_x(1), sigma_y(2)])
+    map = Dict(1=>2)
+    @test_throws ErrorException permute_qubits!(circuit, map)
 end

--- a/test/circuit.jl
+++ b/test/circuit.jl
@@ -216,3 +216,13 @@ end
     map = Dict(1=>2)
     @test_throws ErrorException permute_qubits!(circuit, map)
 end
+
+@testset "permute_qubits" begin
+    circuit = QuantumCircuit(qubit_count=5, gates=[sigma_x(2), sigma_y(3), sigma_z(1),
+        hadamard(4)])
+    map = Dict(1=>3, 3=>1, 2=>5, 5=>2)
+    new_circuit = permute_qubits(circuit, map)
+    expected_circuit = QuantumCircuit(qubit_count=5, gates=[sigma_x(5), sigma_y(1),
+        sigma_z(3), hadamard(4)])
+    @test compare_circuits(new_circuit, expected_circuit)
+end


### PR DESCRIPTION
Adds functions that move the `AbstractGate` object in a `QuantumCircuit` to other qubits.

Fixes #211