### PR TITLE
Feat/add pauli group elements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Alireza Yazdi <alireza@anyonsys.com>", "Paul Le Roux <pleroux@anyons
 version = "0.1.0"
 
 [deps]
+AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -138,6 +138,7 @@ Pauli group elements.
 ```@docs
 Snowflake.PauliGroupElement
 get_pauli
+Base.:*(p1::Snowflake.PauliGroupElement, p2::Snowflake.PauliGroupElement)
 ```
 
 

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -131,6 +131,15 @@ compare_kets
 
 The [SnowflakePlots](https://github.com/anyonlabs/SnowflakePlots.jl) package provides multiple visualization tools for Snowflake.jl. Please see the documentation of [SnowflakePlots](https://github.com/anyonlabs/SnowflakePlots.jl) for more details. 
 
+## Clifford Simulator
+Snowflake provides tools for the efficient storage and manipulation of Clifford gates and
+Pauli group elements.
+
+```@docs
+Snowflake.PauliGroupElement
+get_pauli
+```
+
 
 ```@meta
 DocTestSetup = nothing

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -139,6 +139,9 @@ Pauli group elements.
 Snowflake.PauliGroupElement
 get_pauli
 Base.:*(p1::Snowflake.PauliGroupElement, p2::Snowflake.PauliGroupElement)
+get_quantum_circuit
+get_negative_exponent
+get_imaginary_exponent
 ```
 
 

--- a/src/Snowflake.jl
+++ b/src/Snowflake.jl
@@ -124,6 +124,7 @@ export
 
     get_pauli,
     get_quantum_circuit,
+    get_negative_exponent,
 
     # Gates
     identity_gate,

--- a/src/Snowflake.jl
+++ b/src/Snowflake.jl
@@ -123,6 +123,7 @@ export
     apply_gate!,
 
     get_pauli,
+    get_quantum_circuit,
 
     # Gates
     identity_gate,

--- a/src/Snowflake.jl
+++ b/src/Snowflake.jl
@@ -125,6 +125,7 @@ export
     get_pauli,
     get_quantum_circuit,
     get_negative_exponent,
+    get_imaginary_exponent,
 
     # Gates
     identity_gate,

--- a/src/Snowflake.jl
+++ b/src/Snowflake.jl
@@ -122,6 +122,8 @@ export
     get_transpiler,
     apply_gate!,
 
+    get_pauli,
+
     # Gates
     identity_gate,
     sigma_x,
@@ -156,6 +158,7 @@ include("core/qobj.jl")
 include("core/dynamic_system.jl")
 include("core/quantum_gate.jl")
 include("core/quantum_circuit.jl")
+include("core/clifford.jl")
 include("core/transpile.jl")
 include("anyon/qpu_interface.jl")
 include("anyon/anyon.jl")

--- a/src/core/clifford.jl
+++ b/src/core/clifford.jl
@@ -1,0 +1,113 @@
+using AbstractAlgebra: GFElem, Generic.MatSpaceElem, GF, zero_matrix
+
+const GFInt = GFElem{Int}
+const GFMatrix = MatSpaceElem{GFInt}
+
+"""
+    PauliGroupElement(u::gfp_mat, delta::Int, epsilon::Int)
+A Pauli group element which is represented using the approach of
+[Dehaene and De Moor (2003)](https://doi.org/10.1103/PhysRevA.68.042318).
+"""
+struct PauliGroupElement
+    u::GFMatrix
+    delta::GFInt
+    epsilon::GFInt
+end
+
+function get_pauli(circuit::QuantumCircuit, imaginary_exponent::Integer=0,
+    negative_exponent::Integer=0)::PauliGroupElement
+
+    assert_exponents_are_in_the_field(imaginary_exponent, negative_exponent)
+    num_qubits = get_num_qubits(circuit)
+    pauli = unsafe_get_pauli(Identity(1), num_qubits, imaginary_exponent, negative_exponent)
+    for gate in get_circuit_gates(circuit)
+        new_pauli = unsafe_get_pauli(gate, num_qubits, GF(2)(0), GF(2)(0))
+        pauli = new_pauli*pauli
+    end
+    return pauli
+end
+
+function assert_exponents_are_in_the_field(imaginary_exponent::Integer,
+    negative_exponent::Integer)
+
+    if imaginary_exponent > 1 || imaginary_exponent < 0
+        throw(ErrorException("the imaginary exponent must be 0 or 1"))
+    end
+    if negative_exponent > 1 || negative_exponent < 0
+        throw(ErrorException("the negative exponent must be 0 or 1"))
+    end
+end
+
+function get_pauli(gate::AbstractGate, qubit_count::Integer, imaginary_exponent::Integer=0,
+    negative_exponent::Integer=0)::PauliGroupElement
+
+    target_qubit = get_connected_qubits(gate)[1]
+    if target_qubit > qubit_count
+        throw(ErrorException("the target qubit is not in the circuit"))
+    end
+    assert_exponents_are_in_the_field(imaginary_exponent, negative_exponent)
+    return unsafe_get_pauli(gate, qubit_count, GF(2)(imaginary_exponent),
+        GF(2)(negative_exponent))
+end
+
+function unsafe_get_pauli(gate::Identity, qubit_count::Integer,
+    imaginary_exponent::GFInt, negative_exponent::GFInt)::PauliGroupElement
+    
+    u = zero_matrix(GF(2), 2*qubit_count, 1)
+    return PauliGroupElement(u, imaginary_exponent, negative_exponent)
+end
+
+function unsafe_get_pauli(gate::SigmaX, qubit_count::Integer,
+    imaginary_exponent::GFInt, negative_exponent::GFInt)::PauliGroupElement
+    
+    target_qubit = get_connected_qubits(gate)[1]
+    u = zero_matrix(GF(2), 2*qubit_count, 1)
+    u[2*target_qubit, 1] = 1
+    return PauliGroupElement(u, imaginary_exponent, negative_exponent)
+end
+
+function unsafe_get_pauli(gate::SigmaY, qubit_count::Integer,
+        imaginary_exponent::GFInt, negative_exponent::GFInt)::PauliGroupElement
+    target_qubit = get_connected_qubits(gate)[1]
+    first_index = 2*target_qubit-1
+    u = zero_matrix(GF(2), 2*qubit_count, 1)
+    u[first_index, 1] = 1
+    u[first_index+1, 1] = 1
+    negative_exponent += imaginary_exponent+1
+    imaginary_exponent += 1
+    return PauliGroupElement(u, imaginary_exponent, negative_exponent)
+end
+
+function unsafe_get_pauli(gate::SigmaZ, qubit_count::Integer,
+    imaginary_exponent::GFInt, negative_exponent::GFInt)::PauliGroupElement
+    
+    target_qubit = get_connected_qubits(gate)[1]
+    u = zero_matrix(GF(2), 2*qubit_count, 1)
+    u[2*target_qubit-1, 1] = 1
+    return PauliGroupElement(u, imaginary_exponent, negative_exponent)
+end
+
+function Base.:*(p1::PauliGroupElement, p2::PauliGroupElement)::PauliGroupElement
+
+    new_delta = p1.delta+p2.delta
+    new_u = p1.u+p2.u
+    twice_num_qubits = ncols(new_u)
+    num_qubits = twice_num_qubits/2
+    capital_u = zero_matrix(GF(2), twice_num_qubits, twice_num_qubits)
+    capital_u[1:num_qubits, num_qubits+1:twice_num_qubits] =
+        identity_matrix(GF(2), num_qubits)
+    new_epsilon = p1.epsilon+p2.epsilon+p1.delta*p2.delta+transpose(p2.u)*capital_u*p1.u
+    return PauliGroupElement(new_u, new_delta, new_epsilon)
+end
+
+function Base.:(==)(lhs::PauliGroupElement, rhs::PauliGroupElement)::Bool
+    if lhs.delta != rhs.delta
+        return false
+    elseif lhs.epsilon != rhs.epsilon
+        return false
+    elseif lhs.u != rhs.u
+        return false
+    else
+        return true
+    end
+end

--- a/src/core/clifford.jl
+++ b/src/core/clifford.jl
@@ -161,3 +161,35 @@ function get_imaginary_exponent(pauli::PauliGroupElement)::Int
     displayable_pauli = get_displayable_pauli(pauli)
     return displayable_pauli.imaginary_exponent
 end
+
+function Base.show(io::IO, pauli::PauliGroupElement)
+    println(io, "Pauli Group Element:")
+    displayable_pauli = get_displayable_pauli(pauli)
+    if displayable_pauli.negative_exponent == 1
+        print(io, "-")
+    end
+    print(io, "1.0")
+    if displayable_pauli.imaginary_exponent == 1
+        print(io, "im")
+    end
+    for gate in get_circuit_gates(displayable_pauli.circuit)
+        print_pauli_gate(io, gate)
+    end
+    println(io)
+    println(io)
+end
+
+function print_pauli_gate(io::IO, gate::SigmaX)
+    target = get_connected_qubits(gate)[1]
+    print(io, "*X($(target))")
+end
+
+function print_pauli_gate(io::IO, gate::SigmaY)
+    target = get_connected_qubits(gate)[1]
+    print(io, "*Y($(target))")
+end
+
+function print_pauli_gate(io::IO, gate::SigmaZ)
+    target = get_connected_qubits(gate)[1]
+    print(io, "*Z($(target))")
+end

--- a/src/core/clifford.jl
+++ b/src/core/clifford.jl
@@ -121,7 +121,6 @@ struct DisplayablePauli
 end
 
 function get_displayable_pauli(pauli::PauliGroupElement)
-    println(pauli)
     u = pauli.u
     num_qubits = Int(nrows(u)/2)
     circuit = QuantumCircuit(qubit_count=num_qubits)
@@ -156,4 +155,9 @@ end
 function get_negative_exponent(pauli::PauliGroupElement)::Int
     displayable_pauli = get_displayable_pauli(pauli)
     return displayable_pauli.negative_exponent
+end
+
+function get_imaginary_exponent(pauli::PauliGroupElement)::Int
+    displayable_pauli = get_displayable_pauli(pauli)
+    return displayable_pauli.imaginary_exponent
 end

--- a/src/core/clifford.jl
+++ b/src/core/clifford.jl
@@ -26,9 +26,9 @@ Returns a `PauliGroupElement` given a `circuit` containing Pauli gates.
 
 A Pauli group element corresponds to ``i^\\delta (-1)^\\epsilon \\sigma_a``, where
 ``\\delta`` and ``\\epsilon`` are set by specifying `imaginary_exponent` and
-`negative_exponent`, respectively. The exponents have a default value of 0. As for
-``\\sigma_a``, it is a tensor product of Pauli operators. The Pauli operators are specified
-in the `circuit`.
+`negative_exponent`, respectively. The exponents must be 0 or 1. Their default value is 0.
+As for ``\\sigma_a``, it is a tensor product of Pauli operators. The Pauli operators are
+specified in the `circuit`.
 
 # Examples
 ```jldoctest
@@ -109,10 +109,10 @@ Returns a `PauliGroupElement` given a `gate` and the number of qubits.
 
 A Pauli group element corresponds to ``i^\\delta (-1)^\\epsilon \\sigma_a``, where
 ``\\delta`` and ``\\epsilon`` are set by specifying `imaginary_exponent` and
-`negative_exponent`, respectively. The exponents have a default value of 0. As for
-``\\sigma_a``, it is a tensor product of Pauli operators. In this variant of the `get_pauli`
-function, a single Pauli operator is set by providing a `gate`. The number of qubits
-is specified by `num_qubits`.
+`negative_exponent`, respectively. The exponents must be 0 or 1. Their default value is 0.
+As for ``\\sigma_a``, it is a tensor product of Pauli operators. In this variant of the
+`get_pauli` function, a single Pauli operator is set by providing a `gate`. The number of
+qubits is specified by `num_qubits`.
 
 # Examples
 ```jldoctest
@@ -267,16 +267,98 @@ function get_displayable_pauli(pauli::PauliGroupElement)
     return DisplayablePauli(circuit, lift(imaginary_exponent), lift(negative_exponent))
 end
 
+
+"""
+    get_quantum_circuit(pauli::PauliGroupElement)::QuantumCircuit
+
+Returns the Pauli gates of a `PauliGroupElement` as a `QuantumCircuit`.
+
+# Examples
+```jldoctest
+julia> circuit = QuantumCircuit(qubit_count=2);
+
+julia> push!(circuit, sigma_x(1), sigma_y(2))
+Quantum Circuit Object:
+   qubit_count: 2 
+q[1]:──X───────
+               
+q[2]:───────Y──
+               
+
+
+
+julia> pauli = get_pauli(circuit, imaginary_exponent=1, negative_exponent=1)
+Pauli Group Element:
+-1.0im*X(1)*Y(2)
+
+
+
+julia> get_quantum_circuit(pauli)
+Quantum Circuit Object:
+   qubit_count: 2 
+q[1]:──X───────
+               
+q[2]:───────Y──
+               
+
+
+
+```
+"""
 function get_quantum_circuit(pauli::PauliGroupElement)::QuantumCircuit
     displayable_pauli = get_displayable_pauli(pauli)
     return displayable_pauli.circuit
 end
 
+"""
+    get_negative_exponent(pauli::PauliGroupElement)::Int
+
+Returns the negative exponent of a `PauliGroupElement`.
+
+# Examples
+```jldoctest
+julia> gate = sigma_x(2);
+
+julia> num_qubits = 3;
+
+julia> pauli = get_pauli(gate, num_qubits, negative_exponent=1)
+Pauli Group Element:
+-1.0*X(2)
+
+
+
+julia> get_negative_exponent(pauli)
+1
+
+```
+"""
 function get_negative_exponent(pauli::PauliGroupElement)::Int
     displayable_pauli = get_displayable_pauli(pauli)
     return displayable_pauli.negative_exponent
 end
 
+"""
+    get_imaginary_exponent(pauli::PauliGroupElement)::Int
+
+Returns the imaginary exponent of a `PauliGroupElement`.
+
+# Examples
+```jldoctest
+julia> gate = sigma_x(2);
+
+julia> num_qubits = 3;
+
+julia> pauli = get_pauli(gate, num_qubits, imaginary_exponent=1)
+Pauli Group Element:
+1.0im*X(2)
+
+
+
+julia> get_imaginary_exponent(pauli)
+1
+
+```
+"""
 function get_imaginary_exponent(pauli::PauliGroupElement)::Int
     displayable_pauli = get_displayable_pauli(pauli)
     return displayable_pauli.imaginary_exponent

--- a/src/core/clifford.jl
+++ b/src/core/clifford.jl
@@ -101,50 +101,77 @@ function assert_exponents_are_in_the_field(imaginary_exponent::Integer,
     end
 end
 
-function get_pauli(gate::AbstractGate, qubit_count::Integer; imaginary_exponent::Integer=0,
+"""
+    get_pauli(gate::AbstractGate, num_qubits::Integer; imaginary_exponent::Integer=0,
+        negative_exponent::Integer=0)::PauliGroupElement
+
+Returns a `PauliGroupElement` given a `gate` and the number of qubits.
+
+A Pauli group element corresponds to ``i^\\delta (-1)^\\epsilon \\sigma_a``, where
+``\\delta`` and ``\\epsilon`` are set by specifying `imaginary_exponent` and
+`negative_exponent`, respectively. The exponents have a default value of 0. As for
+``\\sigma_a``, it is a tensor product of Pauli operators. In this variant of the `get_pauli`
+function, a single Pauli operator is set by providing a `gate`. The number of qubits
+is specified by `num_qubits`.
+
+# Examples
+```jldoctest
+julia> gate = sigma_x(2);
+
+julia> num_qubits = 3;
+
+julia> get_pauli(gate, num_qubits)
+Pauli Group Element:
+1.0*X(2)
+
+
+
+```
+"""
+function get_pauli(gate::AbstractGate, num_qubits::Integer; imaginary_exponent::Integer=0,
     negative_exponent::Integer=0)::PauliGroupElement
 
     target_qubit = get_connected_qubits(gate)[1]
-    if target_qubit > qubit_count
+    if target_qubit > num_qubits
         throw(ErrorException("the target qubit is not in the circuit"))
     end
     assert_exponents_are_in_the_field(imaginary_exponent, negative_exponent)
-    return unsafe_get_pauli(gate, qubit_count, GF(2)(imaginary_exponent),
+    return unsafe_get_pauli(gate, num_qubits, GF(2)(imaginary_exponent),
         GF(2)(negative_exponent))
 end
 
-function unsafe_get_pauli(gate::Identity, qubit_count::Integer,
+function unsafe_get_pauli(gate::Identity, num_qubits::Integer,
     imaginary_exponent::GFInt, negative_exponent::GFInt)::PauliGroupElement
     
-    u = zero_matrix(GF(2), 2*qubit_count, 1)
+    u = zero_matrix(GF(2), 2*num_qubits, 1)
     return PauliGroupElement(u, imaginary_exponent, negative_exponent)
 end
 
-function unsafe_get_pauli(gate::SigmaX, qubit_count::Integer,
+function unsafe_get_pauli(gate::SigmaX, num_qubits::Integer,
     imaginary_exponent::GFInt, negative_exponent::GFInt)::PauliGroupElement
     
     target_qubit = get_connected_qubits(gate)[1]
-    u = zero_matrix(GF(2), 2*qubit_count, 1)
-    u[qubit_count+target_qubit, 1] = 1
+    u = zero_matrix(GF(2), 2*num_qubits, 1)
+    u[num_qubits+target_qubit, 1] = 1
     return PauliGroupElement(u, imaginary_exponent, negative_exponent)
 end
 
-function unsafe_get_pauli(gate::SigmaY, qubit_count::Integer,
+function unsafe_get_pauli(gate::SigmaY, num_qubits::Integer,
         imaginary_exponent::GFInt, negative_exponent::GFInt)::PauliGroupElement
     target_qubit = get_connected_qubits(gate)[1]
-    u = zero_matrix(GF(2), 2*qubit_count, 1)
+    u = zero_matrix(GF(2), 2*num_qubits, 1)
     u[target_qubit, 1] = 1
-    u[qubit_count+target_qubit, 1] = 1
+    u[num_qubits+target_qubit, 1] = 1
     negative_exponent += imaginary_exponent+1
     imaginary_exponent += 1
     return PauliGroupElement(u, imaginary_exponent, negative_exponent)
 end
 
-function unsafe_get_pauli(gate::SigmaZ, qubit_count::Integer,
+function unsafe_get_pauli(gate::SigmaZ, num_qubits::Integer,
     imaginary_exponent::GFInt, negative_exponent::GFInt)::PauliGroupElement
     
     target_qubit = get_connected_qubits(gate)[1]
-    u = zero_matrix(GF(2), 2*qubit_count, 1)
+    u = zero_matrix(GF(2), 2*num_qubits, 1)
     u[target_qubit, 1] = 1
     return PauliGroupElement(u, imaginary_exponent, negative_exponent)
 end

--- a/src/core/clifford.jl
+++ b/src/core/clifford.jl
@@ -176,9 +176,42 @@ function unsafe_get_pauli(gate::SigmaZ, num_qubits::Integer,
     return PauliGroupElement(u, imaginary_exponent, negative_exponent)
 end
 
+"""
+    Base.:*(p1::PauliGroupElement, p2::PauliGroupElement)::PauliGroupElement
+
+Returns the product of two `PauliGroupElement` objects.
+
+The `PauliGroupElement` objects must be associated with the same number of qubits.
+
+# Examples
+```jldoctest
+julia> pauli_z = get_pauli(sigma_z(1), 1)
+Pauli Group Element:
+1.0*Z(1)
+
+
+
+julia> pauli_y = get_pauli(sigma_y(1), 1)
+Pauli Group Element:
+1.0*Y(1)
+
+
+
+julia> pauli_z*pauli_y
+Pauli Group Element:
+-1.0im*X(1)
+
+
+
+```
+"""
 function Base.:*(p1::PauliGroupElement, p2::PauliGroupElement)::PauliGroupElement
 
     new_delta = p1.delta+p2.delta
+    if nrows(p1.u) != nrows(p2.u)
+        throw(ErrorException("the Pauli group elements must be associated with the "
+        *"same number of qubits"))
+    end
     new_u = p1.u+p2.u
     twice_num_qubits = nrows(new_u)
     num_qubits = Int(twice_num_qubits/2)

--- a/src/core/clifford.jl
+++ b/src/core/clifford.jl
@@ -19,7 +19,9 @@ function get_pauli(circuit::QuantumCircuit; imaginary_exponent::Integer=0,
 
     assert_exponents_are_in_the_field(imaginary_exponent, negative_exponent)
     num_qubits = get_num_qubits(circuit)
-    pauli = unsafe_get_pauli(Identity(1), num_qubits, imaginary_exponent, negative_exponent)
+    pauli = unsafe_get_pauli(Identity(1), num_qubits, GF(2)(imaginary_exponent),
+        GF(2)(negative_exponent))
+    
     for gate in get_circuit_gates(circuit)
         new_pauli = unsafe_get_pauli(gate, num_qubits, GF(2)(0), GF(2)(0))
         pauli = new_pauli*pauli

--- a/src/core/clifford.jl
+++ b/src/core/clifford.jl
@@ -113,3 +113,20 @@ function Base.:(==)(lhs::PauliGroupElement, rhs::PauliGroupElement)::Bool
         return true
     end
 end
+
+function get_quantum_circuit(pauli::PauliGroupElement)::QuantumCircuit
+    u = pauli.u
+    num_qubits = Int(nrows(u)/2)
+    circuit = QuantumCircuit(qubit_count=num_qubits)
+    for i_qubit = 1:num_qubits
+        u_for_qubit = u[2*i_qubit-1:2*i_qubit, 1]
+        if u_for_qubit == GF(2)[0; 1]
+            push!(circuit, sigma_x(i_qubit))
+        elseif u_for_qubit == GF(2)[1; 1]
+            push!(circuit, sigma_y(i_qubit))
+        elseif u_for_qubit == GF(2)[1; 0]
+            push!(circuit, sigma_z(i_qubit))
+        end
+    end
+    return circuit
+end

--- a/src/core/clifford.jl
+++ b/src/core/clifford.jl
@@ -5,9 +5,12 @@ const GFInt = GFElem{Int}
 const GFMatrix = MatSpaceElem{GFInt}
 
 """
-    PauliGroupElement(u::gfp_mat, delta::Int, epsilon::Int)
+    PauliGroupElement
+
 A Pauli group element which is represented using the approach of
 [Dehaene and De Moor (2003)](https://doi.org/10.1103/PhysRevA.68.042318).
+
+The [`get_pauli`](@ref) functions should be used to generate `PauliGroupElement` objects.
 """
 struct PauliGroupElement
     u::GFMatrix
@@ -15,6 +18,63 @@ struct PauliGroupElement
     epsilon::GFInt
 end
 
+"""
+    get_pauli(circuit::QuantumCircuit; imaginary_exponent::Integer=0,
+        negative_exponent::Integer=0)::PauliGroupElement
+
+Returns a `PauliGroupElement` given a `circuit` containing Pauli gates.
+
+A Pauli group element corresponds to ``i^\\delta (-1)^\\epsilon \\sigma_a``, where
+``\\delta`` and ``\\epsilon`` are set by specifying `imaginary_exponent` and
+`negative_exponent`, respectively. The exponents have a default value of 0. As for
+``\\sigma_a``, it is a tensor product of Pauli operators. The Pauli operators are specified
+in the `circuit`.
+
+# Examples
+```jldoctest
+julia> circuit = QuantumCircuit(qubit_count=2);
+
+julia> push!(circuit, sigma_x(1), sigma_y(2))
+Quantum Circuit Object:
+   qubit_count: 2 
+q[1]:──X───────
+               
+q[2]:───────Y──
+               
+
+
+
+julia> get_pauli(circuit, imaginary_exponent=1, negative_exponent=1)
+Pauli Group Element:
+-1.0im*X(1)*Y(2)
+
+
+
+```
+
+If multiple Pauli gates are applied to the same qubit in the `circuit`, the gates are
+multiplied with the first gate in the `circuit` being the rightmost gate in the
+multiplication.
+
+```jldoctest
+julia> circuit = QuantumCircuit(qubit_count=1);
+
+julia> push!(circuit, sigma_x(1), sigma_z(1))
+Quantum Circuit Object:
+   qubit_count: 1 
+q[1]:──X────Z──
+               
+
+
+
+julia> get_pauli(circuit)
+Pauli Group Element:
+1.0im*Y(1)
+
+
+
+```
+"""
 function get_pauli(circuit::QuantumCircuit; imaginary_exponent::Integer=0,
     negative_exponent::Integer=0)::PauliGroupElement
 

--- a/src/core/clifford.jl
+++ b/src/core/clifford.jl
@@ -1,4 +1,4 @@
-using AbstractAlgebra: GFElem, Generic.MatSpaceElem, GF, zero_matrix
+using AbstractAlgebra: GFElem, Generic.MatSpaceElem, GF, zero_matrix, nrows, identity_matrix
 
 const GFInt = GFElem{Int}
 const GFMatrix = MatSpaceElem{GFInt}
@@ -14,7 +14,7 @@ struct PauliGroupElement
     epsilon::GFInt
 end
 
-function get_pauli(circuit::QuantumCircuit, imaginary_exponent::Integer=0,
+function get_pauli(circuit::QuantumCircuit; imaginary_exponent::Integer=0,
     negative_exponent::Integer=0)::PauliGroupElement
 
     assert_exponents_are_in_the_field(imaginary_exponent, negative_exponent)
@@ -38,7 +38,7 @@ function assert_exponents_are_in_the_field(imaginary_exponent::Integer,
     end
 end
 
-function get_pauli(gate::AbstractGate, qubit_count::Integer, imaginary_exponent::Integer=0,
+function get_pauli(gate::AbstractGate, qubit_count::Integer; imaginary_exponent::Integer=0,
     negative_exponent::Integer=0)::PauliGroupElement
 
     target_qubit = get_connected_qubits(gate)[1]
@@ -91,13 +91,13 @@ function Base.:*(p1::PauliGroupElement, p2::PauliGroupElement)::PauliGroupElemen
 
     new_delta = p1.delta+p2.delta
     new_u = p1.u+p2.u
-    twice_num_qubits = ncols(new_u)
-    num_qubits = twice_num_qubits/2
+    twice_num_qubits = nrows(new_u)
+    num_qubits = Int(twice_num_qubits/2)
     capital_u = zero_matrix(GF(2), twice_num_qubits, twice_num_qubits)
     capital_u[1:num_qubits, num_qubits+1:twice_num_qubits] =
         identity_matrix(GF(2), num_qubits)
     new_epsilon = p1.epsilon+p2.epsilon+p1.delta*p2.delta+transpose(p2.u)*capital_u*p1.u
-    return PauliGroupElement(new_u, new_delta, new_epsilon)
+    return PauliGroupElement(new_u, new_delta, new_epsilon[1,1])
 end
 
 function Base.:(==)(lhs::PauliGroupElement, rhs::PauliGroupElement)::Bool

--- a/test/clifford.jl
+++ b/test/clifford.jl
@@ -35,6 +35,10 @@ end
     @test pauli_x*pauli_y == get_pauli(sigma_z(1), num_qubits, imaginary_exponent=1)
     @test pauli_z*pauli_y == get_pauli(sigma_x(1), num_qubits, imaginary_exponent=1,
         negative_exponent=1)
+
+    num_qubits = 2
+    pauli_x2 = get_pauli(sigma_x(2), num_qubits)
+    @test_throws ErrorException pauli_eye*pauli_x2
 end
 
 @testset "get_pauli_using_circuit" begin

--- a/test/clifford.jl
+++ b/test/clifford.jl
@@ -9,5 +9,30 @@ using Snowflake
     @test outbool
 
     pauli_eye = get_pauli(identity_gate(1), num_qubits)
-    @test !(pauli_eye == pauli_x)
+    @test pauli_eye != pauli_x
+
+    minus_pauli_x = get_pauli(sigma_x(1), num_qubits, negative_exponent=1)
+    @test pauli_x != minus_pauli_x
+
+    i_pauli_x = get_pauli(sigma_x(1), num_qubits, imaginary_exponent=1)
+    @test pauli_x != i_pauli_x
+
+    @test_throws ErrorException get_pauli(sigma_x(2), num_qubits)
+    @test_throws ErrorException get_pauli(sigma_x(1), num_qubits, negative_exponent=-1)
+    @test_throws ErrorException get_pauli(sigma_x(1), num_qubits, negative_exponent=2)
+    @test_throws ErrorException get_pauli(sigma_x(1), num_qubits, imaginary_exponent=-1)
+    @test_throws ErrorException get_pauli(sigma_x(1), num_qubits, imaginary_exponent=2)
+end
+
+@testset "multiply_paulis" begin
+    num_qubits = 1
+    pauli_eye = get_pauli(identity_gate(1), num_qubits)
+    pauli_x = get_pauli(sigma_x(1), num_qubits)
+    pauli_y = get_pauli(sigma_y(1), num_qubits)
+    pauli_z = get_pauli(sigma_z(1), num_qubits)
+
+    @test pauli_x*pauli_eye == pauli_x
+    @test pauli_x*pauli_y == get_pauli(sigma_z(1), num_qubits, imaginary_exponent=1)
+    @test pauli_z*pauli_y == get_pauli(sigma_x(1), num_qubits, imaginary_exponent=1,
+        negative_exponent=1)
 end

--- a/test/clifford.jl
+++ b/test/clifford.jl
@@ -47,3 +47,10 @@ end
     expected_pauli = get_pauli(expected_circuit)
     @test pauli == expected_pauli
 end
+
+@testset "get_quantum_circuit_using_pauli" begin
+    circuit = QuantumCircuit(qubit_count=4, gates=[sigma_z(2), sigma_x(3), sigma_y(4)])
+    pauli = get_pauli(circuit, imaginary_exponent=1, negative_exponent=1)
+    returned_circuit = get_quantum_circuit(pauli)
+    @test compare_circuits(circuit, returned_circuit)
+end

--- a/test/clifford.jl
+++ b/test/clifford.jl
@@ -36,3 +36,14 @@ end
     @test pauli_z*pauli_y == get_pauli(sigma_x(1), num_qubits, imaginary_exponent=1,
         negative_exponent=1)
 end
+
+@testset "get_pauli_using_circuit" begin
+    circuit = QuantumCircuit(qubit_count=4, gates=[sigma_z(2), sigma_x(3), sigma_y(4)])
+    push!(circuit, identity_gate(2), sigma_z(3))
+    pauli = get_pauli(circuit, imaginary_exponent=1, negative_exponent=1)
+    
+    expected_circuit = QuantumCircuit(qubit_count=4,
+        gates=[sigma_z(2), sigma_y(3), sigma_y(4)])
+    expected_pauli = get_pauli(expected_circuit)
+    @test pauli == expected_pauli
+end

--- a/test/clifford.jl
+++ b/test/clifford.jl
@@ -64,3 +64,9 @@ end
     imaginary_exponent = get_imaginary_exponent(pauli)
     @test imaginary_exponent == 0
 end
+
+@testset "print_pauli" begin
+    circuit = QuantumCircuit(qubit_count=4, gates=[sigma_z(2), sigma_x(3), sigma_y(4)])
+    pauli = get_pauli(circuit, imaginary_exponent=1, negative_exponent=1)
+    print(pauli)
+end

--- a/test/clifford.jl
+++ b/test/clifford.jl
@@ -57,7 +57,10 @@ end
 
 @testset "get_exponents" begin
     circuit = QuantumCircuit(qubit_count=4, gates=[sigma_z(2), sigma_x(3), sigma_y(4)])
-    pauli = get_pauli(circuit, imaginary_exponent=1, negative_exponent=1)
+    pauli = get_pauli(circuit, imaginary_exponent=0, negative_exponent=1)
     negative_exponent = get_negative_exponent(pauli)
     @test negative_exponent == 1
+    
+    imaginary_exponent = get_imaginary_exponent(pauli)
+    @test imaginary_exponent == 0
 end

--- a/test/clifford.jl
+++ b/test/clifford.jl
@@ -1,0 +1,13 @@
+using Test
+using Snowflake
+
+@testset "get_pauli" begin
+    num_qubits = 1
+    pauli_x = get_pauli(sigma_x(1), num_qubits)
+    another_pauli_x = get_pauli(sigma_x(1), num_qubits)
+    outbool = pauli_x == another_pauli_x
+    @test outbool
+
+    pauli_eye = get_pauli(identity_gate(1), num_qubits)
+    @test !(pauli_eye == pauli_x)
+end

--- a/test/clifford.jl
+++ b/test/clifford.jl
@@ -54,3 +54,10 @@ end
     returned_circuit = get_quantum_circuit(pauli)
     @test compare_circuits(circuit, returned_circuit)
 end
+
+@testset "get_exponents" begin
+    circuit = QuantumCircuit(qubit_count=4, gates=[sigma_z(2), sigma_x(3), sigma_y(4)])
+    pauli = get_pauli(circuit, imaginary_exponent=1, negative_exponent=1)
+    negative_exponent = get_negative_exponent(pauli)
+    @test negative_exponent == 1
+end

--- a/test/testgroups
+++ b/test/testgroups
@@ -14,3 +14,4 @@ diagonal_gate
 anti_diagonal_gate
 swap_operator
 identity_operator
+clifford


### PR DESCRIPTION
Adds the ability to store and manipulate (e.g. multiply) Pauli group elements.

This feature is needed for the Clifford operator simulator of Issue #223.