### PR TITLE
Feat/sesolve fallback

### DIFF
--- a/src/core/dynamic_system.jl
+++ b/src/core/dynamic_system.jl
@@ -29,7 +29,7 @@ function sesolve(
         ψ_0::Ket{S}, 
         t_range::StepRangeLen; 
         e_ops::Vector{T} where {T<:AbstractOperator}=(T)[], 
-    )::Tuple{Vector{Ket{S}},Matrix{S}} where {S<:Complex}
+    )::Tuple{Vector{Ket{S}},Matrix{<:Real}} where {S<:Complex}
     Hamiltonian(t)=H
     sesolve(Hamiltonian, ψ_0, t_range; e_ops=e_ops)
 end
@@ -39,12 +39,12 @@ function sesolve(
         ψ_0::Ket{S}, 
         t_range::StepRangeLen; 
         e_ops::Vector{T} where {T<:AbstractOperator}=(T)[], 
-    )::Tuple{Vector{Ket{S}},Matrix{S}} where {S<:Complex}
+    )::Tuple{Vector{Ket{S}},Matrix{<:Real}} where {S<:Complex}
     dpsi_dt(t,ψ) = -im*H(t)*ψ
     y=rungekutta2(dpsi_dt, ψ_0, t_range)
     n_t = length(t_range)
     n_o = length(e_ops)
-    observable=zeros(S,n_t, n_o) 
+    observable=zeros(n_t, n_o) 
     for iob in 1:n_o
         for i_t in 1:n_t
             observable[i_t, iob] = real(expected_value(e_ops[iob], y[i_t]))

--- a/src/core/dynamic_system.jl
+++ b/src/core/dynamic_system.jl
@@ -92,11 +92,30 @@ function mesolve(
     t::StepRangeLen; 
     c_ops::Vector{T} where {T<:AbstractOperator}=(T)[], 
     e_ops::Vector{T} where {T<:AbstractOperator}=(T)[], 
-    )::Matrix{<:Real}
-    drho_dt(t,ρ) = -im*commute(H(t),ρ)+sum([A*ρ*A'-0.5*anticommute(A'*A,ρ) for A in c_ops])
+)::Matrix{<:Real}
     n_t = length(t)
     n_o = length(e_ops)
     observable=zeros(n_t, n_o) 
+
+    if length(c_ops) == 0
+        eigenvalues, eigenvectors = eigen(ρ_0)
+
+        n, _ = size(ρ_0)
+        for i in 1:n
+            eigenvalue = eigenvalues[i]
+            eigenvector = eigenvectors[i, :]
+            
+            @assert imag(eigenvalue) ≈ 0
+            
+            if real(eigenvalue) ≉ 0
+                _, observable_i = sesolve(H, Ket(eigenvector), t, e_ops=e_ops)
+                observable += observable_i * real(eigenvalue)
+            end
+        end
+        return observable
+    end
+
+    drho_dt(t,ρ) = -im*commute(H(t),ρ)+sum([A*ρ*A'-0.5*anticommute(A'*A,ρ) for A in c_ops])
 
     ρ = ρ_0
     for i_ob in 1:n_o

--- a/test/dynamic_system.jl
+++ b/test/dynamic_system.jl
@@ -43,4 +43,24 @@ end
         test_relaxation(ComplexF64, Γ, t)
         test_relaxation(ComplexF32, Γ, t)
     end
+
+    @testset "equivalent to sesolve" begin
+        function test_sesolve_rabi(dtype, ω, t)
+            ψ_0 = spin_up(dtype)
+            H = dtype(ω/2.0)*sigma_x(dtype)
+            e_ops = [sigma_z(dtype)]
+            ψ_sesolve , prob_sesolve = sesolve(H, ψ_0, t,e_ops=e_ops)
+
+            ρ_0 = ket2dm(ψ_0)
+            c_ops = Vector{DenseOperator{2, dtype}}([])
+            prob_mesolve = mesolve(H, ρ_0, t, e_ops=e_ops, c_ops=c_ops)
+
+            @test prob_sesolve ≈ prob_mesolve
+        end
+
+        ω = 2.0 * pi
+        t = 0.0:0.01:1.0
+        test_sesolve_rabi(ComplexF64, ω, t)
+        test_sesolve_rabi(ComplexF32, ω, t)
+    end
 end

--- a/test/qobj.jl
+++ b/test/qobj.jl
@@ -1,6 +1,21 @@
 using Snowflake
 using Test
 
+@testset "ket2dm" begin
+    @testset "ensure type consistency" begin
+        function test_consistent_type(dtype)
+            ψ = Ket{dtype}([dtype(1.0), dtype(2.0)])
+
+            ρ = ket2dm(ψ)
+
+            @test typeof(ρ) == DenseOperator{2, dtype}
+        end
+
+        test_consistent_type(ComplexF32)
+        test_consistent_type(ComplexF64)
+    end
+end
+
 @testset "simple_bra_ket" begin
     Ψ_0 = spin_up()
     Ψ_1 = spin_down()

--- a/test/qobj.jl
+++ b/test/qobj.jl
@@ -16,6 +16,19 @@ using Test
     end
 end
 
+@testset "anticommute" begin
+    @testset "ensure type consistency" begin
+        function test_consistent_type(a, b, expectedType)
+            value = anticommute(a, b)
+            @test typeof(value) == expectedType
+        end
+
+        for dtype in (ComplexF64, ComplexF32)
+            test_consistent_type(sigma_x(dtype), sigma_x(dtype), DiagonalOperator{2, dtype})
+        end
+    end
+end
+
 @testset "simple_bra_ket" begin
     Ψ_0 = spin_up()
     Ψ_1 = spin_down()


### PR DESCRIPTION
Fall back to using `sesolve` in `mesolve` when no collapse operators are present.